### PR TITLE
ResolveExpression Callback

### DIFF
--- a/src/DynamicExpresso.Core/DynamicExpresso.Core.csproj
+++ b/src/DynamicExpresso.Core/DynamicExpresso.Core.csproj
@@ -59,6 +59,8 @@
     <Compile Include="IdentifiersInfo.cs" />
     <Compile Include="LanguageConstants.cs" />
     <Compile Include="ParserArguments.cs" />
+    <Compile Include="Parsing\ResolveExpressionType.cs" />
+    <Compile Include="Parsing\ResolveExpressionEventArgs.cs" />
     <Compile Include="Parsing\Token.cs" />
     <Compile Include="Parsing\TokenId.cs" />
     <Compile Include="ReferenceType.cs" />

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -442,8 +442,6 @@ namespace DynamicExpresso
 				throw new Exception("Detected identifiers doesn't match actual identifiers");
 			if (info.Types.Count() != lambda.Types.Count())
 				throw new Exception("Detected types doesn't match actual types");
-			if (info.UnknownIdentifiers.Count() != lambda.UsedParameters.Count())
-				throw new Exception("Detected unknown identifiers doesn't match actual parameters");
 		}
 #endif
 		#endregion

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -100,6 +100,10 @@ namespace DynamicExpresso
 		}
 		#endregion
 
+		#region Events
+		public event EventHandler<ResolveExpressionEventArgs> ResolveUnknownExpression = null;
+		#endregion
+
 		#region Options
 		/// <summary>
 		/// Allows to enable/disable assignment operators. 
@@ -415,7 +419,7 @@ namespace DynamicExpresso
 				                expressionType,
 				                parameters);
 
-			var expression = Parser.Parse(arguments);
+			var expression = Parser.Parse(arguments, ResolveUnknownExpression);
 
 			foreach (var visitor in Visitors)
 				expression = visitor.Visit(expression);

--- a/src/DynamicExpresso.Core/Parsing/ErrorMessages.cs
+++ b/src/DynamicExpresso.Core/Parsing/ErrorMessages.cs
@@ -62,5 +62,6 @@ namespace DynamicExpresso.Parsing
 		public const string CloseBracketOrCommaExpected = "']' or ',' expected";
 		public const string IdentifierExpected = "Identifier expected";
 		public const string TypeIdentifierExpected = "Type identifier expected";
+		public const string ResolveExpressionTwice = "The expression '{0}' on '{1}' '{2}' has already been resolved to '{3}' and cannot be resolved twice.";
 	}
 }

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -16,9 +16,9 @@ namespace DynamicExpresso.Parsing
 {
 	internal class Parser
 	{
-		public static Expression Parse(ParserArguments arguments)
+		public static Expression Parse(ParserArguments arguments, EventHandler<ResolveExpressionEventArgs> resolveEvent)
 		{
-			return new Parser(arguments).Parse();
+			return new Parser(arguments, resolveEvent).Parse();
 		}
 
 		const NumberStyles ParseLiteralNumberStyle = NumberStyles.AllowLeadingSign;
@@ -40,8 +40,11 @@ namespace DynamicExpresso.Parsing
 		BindingFlags _bindingCase;
 		MemberFilter _memberFilterCase;
 
-		Parser(ParserArguments arguments)
+		EventHandler<ResolveExpressionEventArgs> _resolveExpressionEvent;
+
+		Parser(ParserArguments arguments, EventHandler<ResolveExpressionEventArgs> resolveEvent)
 		{
+			_resolveExpressionEvent = resolveEvent;
 			_arguments = arguments;
 
 			_bindingCase = arguments.Settings.CaseInsensitive ? BindingFlags.IgnoreCase : BindingFlags.Default;
@@ -859,6 +862,24 @@ namespace DynamicExpresso.Parsing
 						Expression.Property(instance, (PropertyInfo)member) :
 						Expression.Field(instance, (FieldInfo)member);
 			}
+			
+			// If we didn't find what we searched for, ask for the appropriate Expression via event.
+			if (_resolveExpressionEvent != null)
+			{
+				ResolveExpressionEventArgs eventArgs = new ResolveExpressionEventArgs(
+					ResolveExpressionType.PropertyOrField,
+					type,
+					instance,
+					propertyOrFieldName,
+					null,
+					_memberFilterCase,
+					_bindingCase);
+				_resolveExpressionEvent(this, eventArgs);
+				if (eventArgs.IsResolved)
+				{
+					return eventArgs.ResolvedExpression;
+				}
+			}
 
 			throw CreateParseException(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(type));
 		}
@@ -899,6 +920,24 @@ namespace DynamicExpresso.Parsing
 				return Expression.Call((MethodInfo)method.MethodBase, extensionMethodsArguments);
 			}
 
+			// If we didn't find what we searched for, ask for the appropriate Expression via event.
+			if (_resolveExpressionEvent != null)
+			{
+				ResolveExpressionEventArgs eventArgs = new ResolveExpressionEventArgs(
+					ResolveExpressionType.ExtensionMethod,
+					type,
+					instance,
+					id,
+					args,
+					_memberFilterCase,
+					_bindingCase);
+				_resolveExpressionEvent(this, eventArgs);
+				if (eventArgs.IsResolved)
+				{
+					return eventArgs.ResolvedExpression;
+				}
+			}
+
 			return null;
 		}
 
@@ -913,6 +952,24 @@ namespace DynamicExpresso.Parsing
 				var method = applicableMethods[0];
 
 				return Expression.Call(instance, (MethodInfo)method.MethodBase, method.PromotedParameters);
+			}
+
+			// If we didn't find what we searched for, ask for the appropriate Expression via event.
+			if (_resolveExpressionEvent != null)
+			{
+				ResolveExpressionEventArgs eventArgs = new ResolveExpressionEventArgs(
+					ResolveExpressionType.Method,
+					type,
+					instance,
+					id,
+					args,
+					_memberFilterCase,
+					_bindingCase);
+				_resolveExpressionEvent(this, eventArgs);
+				if (eventArgs.IsResolved)
+				{
+					return eventArgs.ResolvedExpression;
+				}
 			}
 
 			return null;

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -642,6 +642,25 @@ namespace DynamicExpresso.Parsing
 				return parameterExpression;
 			}
 
+			// If we didn't find what we searched for, ask for the appropriate Expression via event.
+			if (_resolveExpressionEvent != null)
+			{
+				ResolveExpressionEventArgs eventArgs = new ResolveExpressionEventArgs(
+					ResolveExpressionType.Identifier,
+					null,
+					null,
+					_token.text,
+					null,
+					_memberFilterCase,
+					_bindingCase);
+				_resolveExpressionEvent(this, eventArgs);
+				if (eventArgs.IsResolved)
+				{
+					NextToken();
+					return eventArgs.ResolvedExpression;
+				}
+			}
+
 			// Working context implementation
 			//if (it != null)
 			//    return ParseMemberAccess(null, it);

--- a/src/DynamicExpresso.Core/Parsing/ResolveExpressionEventArgs.cs
+++ b/src/DynamicExpresso.Core/Parsing/ResolveExpressionEventArgs.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace DynamicExpresso.Parsing
+{
+	public class ResolveExpressionEventArgs : EventArgs
+	{
+		private ResolveExpressionType _eventType;
+		private Type _type;
+		private Expression _instance;
+		private string _name;
+		private Expression[] _args;
+		private MemberFilter _memberFilter;
+		private BindingFlags _bindingFlags;
+		private Expression _resolvedExpression;
+
+		public ResolveExpressionType EventType
+		{
+			get { return _eventType; }
+		}
+		public Type Type
+		{
+			get { return _type; }
+		}
+		public Expression Instance
+		{
+			get { return _instance; }
+		}
+		public string Name
+		{
+			get { return _name; }
+		}
+		public IEnumerable<Expression> Arguments
+		{
+			get { return _args; }
+		}
+		public MemberFilter MemberFilter
+		{
+			get { return _memberFilter; }
+		}
+		public BindingFlags BindingFlags
+		{
+			get { return _bindingFlags; }
+		}
+		public bool IsResolved
+		{
+			get { return _resolvedExpression != null; }
+		}
+		internal Expression ResolvedExpression
+		{
+			get { return _resolvedExpression; }
+		}
+
+		public ResolveExpressionEventArgs(ResolveExpressionType eventType, Type type, Expression instance, string name, Expression[] args, MemberFilter memberFilter, BindingFlags bindingFlags)
+		{
+			_eventType = eventType;
+			_type = type;
+			_instance = instance;
+			_name = name;
+			_args = args;
+			_memberFilter = memberFilter;
+			_bindingFlags = bindingFlags;
+		}
+
+		public void Resolve(Expression expression)
+		{
+			if (IsResolved)
+			{ 
+				throw new InvalidOperationException(string.Format(
+					ErrorMessages.ResolveExpressionTwice, 
+					_name, 
+					_type, 
+					_instance, 
+					_resolvedExpression));
+			}
+			_resolvedExpression = expression;
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Parsing/ResolveExpressionType.cs
+++ b/src/DynamicExpresso.Core/Parsing/ResolveExpressionType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace DynamicExpresso.Parsing
+{
+	public enum ResolveExpressionType
+	{
+		Unknown,
+
+		PropertyOrField,
+		Method,
+		ExtensionMethod
+	}
+}

--- a/src/DynamicExpresso.Core/Parsing/ResolveExpressionType.cs
+++ b/src/DynamicExpresso.Core/Parsing/ResolveExpressionType.cs
@@ -10,6 +10,7 @@ namespace DynamicExpresso.Parsing
 	{
 		Unknown,
 
+		Identifier,
 		PropertyOrField,
 		Method,
 		ExtensionMethod


### PR DESCRIPTION
I have added an optional event to the Interpreter class that allows users to resolve a Property-, Field-, Method- or Extension Method Expression manually whenever the default resolve fails. A quick example:

```C#
public class Program
{
	public static void Main(string[] args)
	{
		// Trying to access the length of an object - this will not work without this update!
		Func<object,object> func;
		string expression = "arg.Length";

		// Creating an interpreter and subscribing to the optional resolve event
		Interpreter interpreter = new Interpreter();
		interpreter.ResolveUnknownExpression += ResolveUnknownExpression;
		
		// Now let's try to parse this...
		func = interpreter.ParseAsDelegate<Func<object,object>>(expression, "arg");

		// Works!
		Console.WriteLine(func("Hello"));
		Console.ReadLine();
	}

	// This event handler is called whenever the Interpreter fails to resolve an Expression.
	// It can be used to provide a suitable replacement on-the-fly. It will not be called when
	// the Parser is able to resolve the Expression by itself.
	private static void ResolveUnknownExpression(object sender, ResolveExpressionEventArgs e)
	{
		// If we're trying to resolve a Property or Field named "Length"...
		if (e.EventType == ResolveExpressionType.PropertyOrField && 
			e.Name == "Length")
		{
			// Let's just assume we're dealing with a string and cast it.
			e.Resolve(Expression.Property(Expression.TypeAs(e.Instance, typeof(string)), "Length"));
		}
	}
}
```

Please note that this is just a random example in order to illustrate how it works.

I will be using this for interpreting Expressions like `something.Parent.Name` where there is no actual object with those members, but rather a backend that will provide these values dynamically. Without these changes, I wouldn't be able to achieve this using DynamicExpresso, so I hope that it might be useful to others, too.

Let me know if you have any feedback on this.