### PR TITLE
Fixed performance issue where Interpreter's ctor ran too slow

### DIFF
--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace DynamicExpresso
 {
@@ -278,13 +279,9 @@ namespace DynamicExpresso
 
 			_settings.KnownTypes[type.Name] = type;
 
-			var extensions = ReflectionExtensions.GetExtensionMethods(type.Type);
-			foreach (var extensionMethod in extensions)
+		    foreach (var extensionMethod in type.ExtensionMethods)
 			{
-				if (!_settings.ExtensionMethods.Contains(extensionMethod))
-				{
-					_settings.ExtensionMethods.Add(extensionMethod);
-				}
+			    _settings.ExtensionMethods.Add(extensionMethod);	
 			}
 
 			return this;

--- a/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
@@ -12,7 +12,7 @@ namespace DynamicExpresso.Parsing
 	{
 		readonly Dictionary<string, Identifier> _identifiers;
 		readonly Dictionary<string, ReferenceType> _knownTypes;
-		readonly List<MethodInfo> _extensionMethods;
+		readonly HashSet<MethodInfo> _extensionMethods;
 
 		public ParserSettings(bool caseInsensitive)
 		{
@@ -26,7 +26,7 @@ namespace DynamicExpresso.Parsing
 
 			_knownTypes = new Dictionary<string, ReferenceType>(KeyComparer);
 
-			_extensionMethods = new List<MethodInfo>();
+			_extensionMethods = new HashSet<MethodInfo>();
 
 			AssignmentOperators = AssignmentOperators.All;
 		}
@@ -41,7 +41,7 @@ namespace DynamicExpresso.Parsing
 			get { return _identifiers; }
 		}
 
-		public IList<MethodInfo> ExtensionMethods
+		public HashSet<MethodInfo> ExtensionMethods
 		{
 			get { return _extensionMethods; }
 		}

--- a/src/DynamicExpresso.Core/ReferenceType.cs
+++ b/src/DynamicExpresso.Core/ReferenceType.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DynamicExpresso.Reflection;
 
 namespace DynamicExpresso
 {
@@ -11,7 +15,9 @@ namespace DynamicExpresso
 		/// </summary>
 		public string Name { get; private set; }
 
-		public ReferenceType(string name, Type type)
+	    public IList<MethodInfo> ExtensionMethods { get; private set; }
+
+	    public ReferenceType(string name, Type type)
 		{
 			if (string.IsNullOrWhiteSpace(name))
 				throw new ArgumentNullException("name");
@@ -21,6 +27,7 @@ namespace DynamicExpresso
 
 			Type = type;
 			Name = name;
+	        ExtensionMethods = ReflectionExtensions.GetExtensionMethods(type).ToList();
 		}
 
 		public ReferenceType(Type type)
@@ -30,6 +37,7 @@ namespace DynamicExpresso
 
 			Type = type;
 			Name = type.Name;
+            ExtensionMethods = ReflectionExtensions.GetExtensionMethods(type).ToList();
 		}
 	}
 }

--- a/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
+++ b/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -36,16 +37,15 @@ namespace DynamicExpresso.Reflection
 
 		public static IEnumerable<MethodInfo> GetExtensionMethods(Type type)
 		{
-			if (type.IsSealed && !type.IsGenericType && !type.IsNested)
+			if (type.IsSealed && type.IsAbstract && !type.IsGenericType && !type.IsNested)
 			{
 				var query = from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
 										where method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false)
 										select method;
-
 				return query;
 			}
 
-			return new MethodInfo[0];
+			return Enumerable.Empty<MethodInfo>();
 		}
 
 		public class DelegateInfo

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -42,6 +42,7 @@
     <Compile Include="CaseInsensitivePropertyTest.cs" />
     <Compile Include="DetectIdentifiersTest.cs" />
     <Compile Include="IdentifiersTest.cs" />
+    <Compile Include="PerformanceTest.cs" />
     <Compile Include="VisitorsTest.cs" />
     <Compile Include="ReferencedTypesPropertyTest.cs" />
     <Compile Include="CollectionHelperTests.cs" />

--- a/test/DynamicExpresso.UnitTest/PerformanceTest.cs
+++ b/test/DynamicExpresso.UnitTest/PerformanceTest.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using NUnit.Framework;
+
+namespace DynamicExpresso.UnitTest
+{
+    [TestFixture]
+    public class PerformanceTest
+    {
+        [Test]
+        public void InterperterCreation()
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+           
+            for (int i = 0; i < 1000; i++)
+            {
+                new Interpreter(InterpreterOptions.Default);      
+            }
+
+            Assert.Less(stopwatch.ElapsedMilliseconds,200);
+          }
+    }
+}


### PR DESCRIPTION
Hi,

I've been using DynamicExpresso indirectly via @Alex141 's CalcBinding library, and it is fantastic!
However, when using the library extensively I've found there to be a performance issue inside of Interpreter constructor. 

Here is a profiling snapshot from dotTrace:
![image](https://cloud.githubusercontent.com/assets/641292/8743825/e889819c-2c7a-11e5-8111-0e9404d2781d.png)

I later created a test and found that creating 1000 Interpreter instances on my modern machine took just over 4 seconds.
 


I've eliminated the problem by adding a few fixes:
1. Switched to using a HashSet instead of a List
2. Only load the extension methods once per primitive type
3. Only attempt to read extension methods from System.Type's that represent static classes (both .IsSealed and .IsAbstract are true)

Added a unit test to prevent regression.