### PR TITLE
Fix: >1 overload params[] methods suit given args

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1622,6 +1622,13 @@ namespace DynamicExpresso.Parsing
 			return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
 		}
 
+		static Type GetParameterType(ParameterInfo parameterInfo)
+		{
+			bool isParamsArray = HasParamsArrayType(parameterInfo);
+			Type type = isParamsArray ? parameterInfo.ParameterType.GetElementType() : parameterInfo.ParameterType;
+			return type;
+		}
+
 		static bool MethodHasPriority(Expression[] args, MethodData method, MethodData otherMethod)
 		{
 			if (method.HasParamsArray == false && otherMethod.HasParamsArray)
@@ -1637,22 +1644,14 @@ namespace DynamicExpresso.Parsing
 			bool better = false;
 			for (int i = 0; i < args.Length; i++)
 			{
-				ParameterInfo methodParameter = method.Parameters[i];
-				ParameterInfo otherMethodParameter = otherMethod.Parameters[i];
-				bool isMethodParameterHasParamsArrayType = HasParamsArrayType(methodParameter);
-				bool isOtherMethodParameterHasParamsArrayType = HasParamsArrayType(otherMethodParameter);
-				Type methodParamType = isMethodParameterHasParamsArrayType 
-					? methodParameter.ParameterType.GetElementType()
-					: methodParameter.ParameterType;
-				Type otherMethodParamType = isOtherMethodParameterHasParamsArrayType
-					? otherMethodParameter.ParameterType.GetElementType()
-					: otherMethodParameter.ParameterType;
-				int c = CompareConversions(args[i].Type,
-						methodParamType,
-						otherMethodParamType);
+				ParameterInfo methodParam = method.Parameters[i];
+				ParameterInfo otherMethodParam = otherMethod.Parameters[i];
+				Type methodParamType = GetParameterType(methodParam);
+				Type otherMethodParamType = GetParameterType(otherMethodParam);
+				int c = CompareConversions(args[i].Type, methodParamType, otherMethodParamType);
 				if (c < 0) return false;
 				if (c > 0) better = true;
-				if (isMethodParameterHasParamsArrayType || isOtherMethodParameterHasParamsArrayType)
+				if (HasParamsArrayType(methodParam) || HasParamsArrayType(otherMethodParam))
 				{
 					break;
 				}

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -262,6 +262,15 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(1, x.AmbiguousMethod_ParamsArrayCalls);
 		}
 
+		[Test]
+		public void Overload_paramsArray_methods_with_compatible_type_params()
+		{
+			var target = new Interpreter();
+			var x = new MyTestService();
+			target.SetVariable("x", x);
+			Assert.AreEqual(3, target.Eval("x.OverloadMethodWithParamsArray(2, 3, 1)"));
+		}
+
 		interface MyTestInterface
 		{
 		}
@@ -339,6 +348,15 @@ namespace DynamicExpresso.UnitTest
 			public void AmbiguousMethod(DateTime fixedParam, int p1, int p2)
 			{
 				AmbiguousMethod_NormalCalls++;
+			}
+
+			public int OverloadMethodWithParamsArray(params int[] paramsArray)
+			{
+				return paramsArray.Max();
+			}
+			public long OverloadMethodWithParamsArray(params long[] paramsArray)
+			{
+				return paramsArray.Max();
 			}
 		}
 


### PR DESCRIPTION
I.e. expression is "Utils.Max(1, 2, 3)" and there are methods
`int Max(params int[] values)`
`long Max(params long[] values)`
In such case lib method Parser.FindBestMethod has more than 1 applicable methods and invokes method MethodHasPriority.
In this method there's no check if parameters have ParamsArrayType and it throws exception on method.Parameters[i] "Out of range" exception.
I've handled this situation in the method MethodHasPriority.