### PR TITLE
Variables and parameters should take precedence over known types.

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -623,12 +623,6 @@ namespace DynamicExpresso.Parsing
 			if (_token.text == ParserConstants.KEYWORD_TYPEOF)
 				return ParseTypeof();
 
-			Type knownType;
-			if (_arguments.TryGetKnownType(_token.text, out knownType))
-			{
-				return ParseTypeKeyword(knownType);
-			}
-
 			Expression keywordExpression;
 			if (_arguments.TryGetIdentifier(_token.text, out keywordExpression))
 			{
@@ -641,6 +635,12 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				return parameterExpression;
+			}
+
+			Type knownType;
+			if (_arguments.TryGetKnownType(_token.text, out knownType))
+			{
+				return ParseTypeKeyword(knownType);
 			}
 
 			// Working context implementation

--- a/test/DynamicExpresso.UnitTest/ParametersTest.cs
+++ b/test/DynamicExpresso.UnitTest/ParametersTest.cs
@@ -51,6 +51,19 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Parameters_should_take_precedence_over_known_types()
+		{
+			var target = new Interpreter();
+
+			var parameters = new[] {
+				new Parameter("Int1", 23),
+				new Parameter("Int32", 7)
+			};
+
+			Assert.AreEqual(30, target.Eval("Int1 + Int32", parameters));
+		}
+
+		[Test]
 		public void Expression_Without_Parameters()
 		{
 			var target = new Interpreter();

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -69,6 +69,16 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Variables_should_take_precedence_over_known_types()
+		{
+			var o = new {Foo = "bar"};
+			var target = new Interpreter(InterpreterOptions.DefaultCaseInsensitive)
+				.SetVariable("Object", o);
+
+			Assert.AreEqual("bar", target.Eval("Object.Foo"));
+		}
+
+		[Test]
 		public void Null_Variables()
 		{
 			var target = new Interpreter()


### PR DESCRIPTION
Ran into this issue while trying to use `Object` as a variable name.