### PR TITLE
Support calling functions with default parameters

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1280,7 +1280,7 @@ namespace DynamicExpresso.Parsing
 
 		private static bool CheckIfMethodIsApplicableAndPrepareIt(MethodData method, Expression[] args)
 		{
-			if (method.Parameters.Length > args.Length)
+			if (method.Parameters.Count(y => !y.HasDefaultValue) > args.Length)
 				return false;
 
 			var promotedArgs = new List<Expression>();
@@ -1358,6 +1358,9 @@ namespace DynamicExpresso.Parsing
 					throw new Exception("Type is not an array, element not found");
 				promotedArgs.Add(Expression.NewArrayInit(paramsArrayElementType, paramsArrayPromotedArgument));
 			}
+
+			// Add default params, if needed.
+			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select(x => Expression.Constant(x.DefaultValue)));
 
 			method.PromotedParameters = promotedArgs.ToArray();
 

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -270,6 +270,29 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 			Assert.AreEqual(3, target.Eval("x.OverloadMethodWithParamsArray(2, 3, 1)"));
 		}
+		
+		[Test]
+		public void Method_with_optional_param()
+		{
+			var target = new Interpreter();
+
+			var x = new MyTestService();
+			var y = "1";
+			var z = "2";
+			var w = "3";
+			var parameters = new[] {
+				new Parameter("x", x.GetType(), x),
+				new Parameter("y", y.GetType(), y),
+				new Parameter("z", z.GetType(), z),
+				new Parameter("w", w.GetType(), w)
+			};
+
+			Assert.AreEqual(x.MethodWithOptionalParam(y), target.Eval("x.MethodWithOptionalParam(y)", parameters));
+			Assert.AreEqual(x.MethodWithOptionalParam(y, z), target.Eval("x.MethodWithOptionalParam(y, z)", parameters));
+			Assert.AreEqual(x.MethodWithOptionalParam(z, y), target.Eval("x.MethodWithOptionalParam(z, y)", parameters));
+			Assert.AreEqual(x.MethodWithOptionalParam(y, z, w), target.Eval("x.MethodWithOptionalParam(y, z, w)", parameters));
+			Assert.AreEqual(x.MethodWithOptionalParam(w, y, z), target.Eval("x.MethodWithOptionalParam(w, y, z)", parameters));
+		}
 
 		private interface MyTestInterface
 		{
@@ -325,6 +348,11 @@ namespace DynamicExpresso.UnitTest
 			public string MethodWithGenericParam<T>(string a, T p)
 			{
 				return string.Format("{0} {1}", a, p);
+			}
+
+			public string MethodWithOptionalParam(string param1, string param2 = "2", string param3 = "3")
+			{
+				return string.Format("{0} {1} {2}", param1, param2, param3);
 			}
 
 			public DateTime this[int i]


### PR DESCRIPTION
At the moment, calling a method with default arguments without defining them explicitly causes a failure:

Consider this example:

```
    class Program
    {
        class test
        {
            public string abc(int a, int b = 5, int c = 10)
            {
                return (a + b +c).ToString();
            }
        }
        static void Main(string[] args)
        {
            Interpreter a = new Interpreter();
            a.SetVariable("Test", new test());
            Console.WriteLine(a.Eval<string>("Test.abc(2)")); //fails
            Console.WriteLine(a.Eval<string>("Test.abc(2,5)")); //fails
            Console.WriteLine(a.Eval<string>("Test.abc(2,4,11)")); //ok
            //Console.WriteLine(a.Eval<string>("Test.abc(2,4,11,12)")); // correct to be fail
            //Console.WriteLine(a.Eval<string>("Test.abc()")); // correct to be fail
            Console.ReadKey();
        }
    }
```

The first and second eval will fail with an exception saying no suitable method was found in Test, while clearly abc(int, int = 5, int = 10) is suitable for both. 

The patch allows these two cases to be handled by filling the missing parameters with their default values, if available, while preparing the method.

The third eval worked, and still works with the patch, as expected.

The forth eval didn't work, and still doesn't work with the patch, as expected.

The fifth eval didn't work, and still doesn't work with the patch, as expected as the first parameter doesn't have a default value defined.