### PR TITLE
Adding support to inject custom converters

### DIFF
--- a/src/DynamicExpresso.Core/Converters/IConverter.cs
+++ b/src/DynamicExpresso.Core/Converters/IConverter.cs
@@ -1,0 +1,7 @@
+﻿namespace DynamicExpresso.Converters
+{
+	public interface IConverter
+	{
+		object Convert(string text);
+	}
+}

--- a/src/DynamicExpresso.Core/Converters/IntegerConverter.cs
+++ b/src/DynamicExpresso.Core/Converters/IntegerConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Globalization;
+
+namespace DynamicExpresso.Converters
+{
+	public class IntegerConverter : IConverter
+	{
+		private const NumberStyles ParseLiteralUnsignedNumberStyle = NumberStyles.AllowLeadingSign;
+		private const NumberStyles ParseLiteralNumberStyle = NumberStyles.AllowLeadingSign;
+
+		private static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
+
+		public virtual object Convert(string text)
+		{
+			if (text[0] != '-')
+			{
+				if (!ulong.TryParse(text, ParseLiteralUnsignedNumberStyle, ParseCulture, out ulong value))
+					throw new Exception();
+
+				if (value <= int.MaxValue)
+					return (int)value;
+				if (value <= uint.MaxValue)
+					return (uint)value;
+				if (value <= long.MaxValue)
+					return (long)value;
+
+				return value;
+			}
+			else
+			{
+				if (!long.TryParse(text, ParseLiteralNumberStyle, ParseCulture, out long value))
+					throw new Exception();
+
+				if (value >= int.MinValue && value <= int.MaxValue)
+					return (int)value;
+
+				return value;
+			}
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Converters/RealConverter.cs
+++ b/src/DynamicExpresso.Core/Converters/RealConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Globalization;
+
+namespace DynamicExpresso.Converters
+{
+	public class RealConverter : IConverter
+	{
+		private const NumberStyles ParseLiteralUnsignedNumberStyle = NumberStyles.AllowLeadingSign;
+		private const NumberStyles ParseLiteralNumberStyle = NumberStyles.AllowLeadingSign;
+		private const NumberStyles ParseLiteralDecimalNumberStyle = NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint;
+
+		private static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
+
+		public virtual object Convert(string text)
+		{
+			object value = null;
+			var last = text[text.Length - 1];
+
+			if (last == 'F' || last == 'f')
+			{
+				if (float.TryParse(text.Substring(0, text.Length - 1), ParseLiteralDecimalNumberStyle, ParseCulture, out float f))
+					value = f;
+			}
+			else if (last == 'M' || last == 'm')
+			{
+				if (decimal.TryParse(text.Substring(0, text.Length - 1), ParseLiteralDecimalNumberStyle, ParseCulture, out decimal dc))
+					value = dc;
+			}
+			else
+			{
+				if (double.TryParse(text, ParseLiteralDecimalNumberStyle, ParseCulture, out double d))
+					value = d;
+			}
+
+			if (value == null)
+				throw new Exception();
+
+			return value;
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using DynamicExpresso.Exceptions;
+using DynamicExpresso.Converters;
 
 namespace DynamicExpresso
 {
@@ -304,6 +305,11 @@ namespace DynamicExpresso
 			return Parse(expressionText, typeof(void), parameters);
 		}
 
+		public Lambda Parse(string expressionText, IConverter integerConverter, IConverter realConverter, params Parameter[] parameters)
+		{
+			return Parse(expressionText, typeof(void), integerConverter, realConverter, parameters);
+		}
+
 		/// <summary>
 		/// Parse a text expression and returns a Lambda class that can be used to invoke it.
 		/// If the expression cannot be converted to the type specified in the expressionType parameter
@@ -317,6 +323,11 @@ namespace DynamicExpresso
 		public Lambda Parse(string expressionText, Type expressionType, params Parameter[] parameters)
 		{
 			return ParseAsLambda(expressionText, expressionType, parameters);
+		}
+
+		public Lambda Parse(string expressionText, Type expressionType, IConverter integerConverter, IConverter realConverter, params Parameter[] parameters)
+		{
+			return ParseAsLambda(expressionText, expressionType, parameters, integerConverter, realConverter);
 		}
 
 		[Obsolete("Use ParseAsDelegate<TDelegate>(string, params string[])")]
@@ -408,13 +419,15 @@ namespace DynamicExpresso
 
 		#region Private methods
 
-		private Lambda ParseAsLambda(string expressionText, Type expressionType, Parameter[] parameters)
+		private Lambda ParseAsLambda(string expressionText, Type expressionType, Parameter[] parameters, IConverter integerConverter = null, IConverter realConverter = null)
 		{
 			var arguments = new ParserArguments(
 												expressionText,
 												_settings,
 												expressionType,
-												parameters);
+												parameters,
+												integerConverter,
+												realConverter);
 
 			var expression = Parser.Parse(arguments);
 

--- a/src/DynamicExpresso.Core/ParserArguments.cs
+++ b/src/DynamicExpresso.Core/ParserArguments.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using DynamicExpresso.Exceptions;
+using DynamicExpresso.Converters;
 
 namespace DynamicExpresso
 {
@@ -16,7 +17,7 @@ namespace DynamicExpresso
 		private readonly HashSet<ReferenceType> _usedTypes = new HashSet<ReferenceType>();
 		private readonly HashSet<Identifier> _usedIdentifiers = new HashSet<Identifier>();
 
-		public ParserArguments(
+		private ParserArguments(
 			string expressionText, 
 			ParserSettings settings, 
 			Type expressionReturnType,
@@ -40,6 +41,21 @@ namespace DynamicExpresso
 				}
 			}
 		}
+
+		public ParserArguments(
+			string expressionText,
+			ParserSettings settings,
+			Type expressionReturnType,
+			IEnumerable<Parameter> declaredParameters,
+			IConverter intergerConverter,
+			IConverter realConverter) : this(expressionText, settings, expressionReturnType, declaredParameters)
+		{
+			IntegerConverter = intergerConverter ?? new IntegerConverter();
+			RealConverter = realConverter ?? new RealConverter();
+		}
+
+		public IConverter IntegerConverter { get; }
+		public IConverter RealConverter { get; }
 
 		public ParserSettings Settings { get; private set;}
 		public string ExpressionText { get; private set; }

--- a/test/DynamicExpresso.UnitTest/ConvertersTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConvertersTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using DynamicExpresso.Exceptions;
+using NUnit.Framework;
+
+namespace DynamicExpresso.UnitTest
+{
+	[TestFixture]
+	public class ConvertersTest
+	{
+		class IntegerConveter : Converters.IConverter
+		{
+			public object Convert(string text)
+			{
+				if (!decimal.TryParse(text, out decimal result))
+					throw new Exception();
+
+				return result;
+			}
+		}
+
+		[Test]
+		public void Multiplicate_Nullable_Decimal_By_Integer_Number()
+		{
+			var target = new Interpreter();
+
+			var expression = target.Parse("x * y * 100", 
+				new IntegerConveter(), null,
+				new Parameter("x", typeof(decimal)), new Parameter("y", typeof(decimal?)));
+
+			Assert.AreEqual(7 * 3 * 100, expression.Invoke(7M, 3M));
+		}
+	}
+}

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -19,5 +19,9 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\DynamicExpresso.Core\DynamicExpresso.Core.csproj" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+	</ItemGroup>
 	
 </Project>


### PR DESCRIPTION
My expression has integer numbers operating with nullable decimals. In this case, an expression compatibility problem happens when I parse a simple multiplication: x * 100, where x is a nullable decimal parameter.

Then, I needed to extend the conversion behavior to enable custom number conversions that can be passed by the developer through parameters. 

After this implementation, I solved my problem writing a custom IntegerConverter in my project. This custom IntegerConverter converts all numbers to decimal. 
