### PR TITLE
Handle default parameters type explicitly

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1428,7 +1428,7 @@ namespace DynamicExpresso.Parsing
 			}
 
 			// Add default params, if needed.
-			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select(x => Expression.Constant(x.DefaultValue)));
+			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select(x => Expression.Constant(x.DefaultValue, x.ParameterType)));
 
 			method.PromotedParameters = promotedArgs.ToArray();
 

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -394,6 +394,24 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(x.MethodWithOptionalParam(w, y, z), target.Eval("x.MethodWithOptionalParam(w, y, z)", parameters));
 		}
 
+		[Test]
+		public void Method_with_optional_null_param()
+		{
+			var target = new Interpreter();
+
+			var x = new MyTestService();
+			var y = "1";
+			var z = "2";
+			var parameters = new[] {
+				new Parameter("x", x.GetType(), x),
+				new Parameter("y", y.GetType(), y),
+				new Parameter("z", z.GetType(), z),
+			};
+
+			Assert.AreEqual(x.MethodWithOptionalNullParam(y), target.Eval("x.MethodWithOptionalNullParam(y)", parameters));
+			Assert.AreEqual(x.MethodWithOptionalNullParam(y, z), target.Eval("x.MethodWithOptionalNullParam(y, z)", parameters));
+		}
+
 		private interface MyTestInterface
 		{
 		}
@@ -454,6 +472,11 @@ namespace DynamicExpresso.UnitTest
 			public string MethodWithOptionalParam(string param1, string param2 = "2", string param3 = "3")
 			{
 				return string.Format("{0} {1} {2}", param1, param2, param3);
+			}
+
+			public string MethodWithOptionalNullParam(string param1, string param2 = null)
+			{
+				return string.Format("{0} {1}", param1, param2 ?? "(null)");
 			}
 
 			public DateTime this[int i]


### PR DESCRIPTION
When an argument default value is gathered from a method definition be sure to pass also its associated argument when creating the Expression.Constant.

This avoids a problem which happens when the argument is null: in this case the type of the argument will be System.Object and that will fail when binding the arguments to a method defining a different type (for example string)

Additionally see remarks section from https://docs.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression.constant?view=netframework-4.7.2#System_Linq_Expressions_Expression_Constant_System_Object_ )

In addition a new unit test was added to showcase this situation.