### PR TITLE
Parser.cs splitting

### DIFF
--- a/src/DynamicExpresso.Core/Exceptions/ParseException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/ParseException.cs
@@ -12,10 +12,15 @@ namespace DynamicExpresso.Exceptions
 	#endif
 	public class ParseException : DynamicExpressoException
 	{
-		public ParseException(string message, int position)
+		protected ParseException(string message, int position)
 			: base(string.Format(ErrorMessages.Format, message, position)) 
 		{
 			Position = position;
+		}
+
+		internal static Exception Create(int pos, string format, params object[] args)
+		{
+			return new ParseException(string.Format(format, args), pos);
 		}
 
 		public int Position { get; private set; }

--- a/src/DynamicExpresso.Core/Parsing/Expressions.cs
+++ b/src/DynamicExpresso.Core/Parsing/Expressions.cs
@@ -1,0 +1,663 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using DynamicExpresso.Exceptions;
+using DynamicExpresso.Resources;
+
+namespace DynamicExpresso.Parsing
+{
+	internal class Expressions
+	{
+		private readonly BindingFlags _bindingCase;
+		private readonly MemberFilter _memberFilterCase;
+
+		public Expressions(ParserArguments arguments)
+		{
+			_bindingCase = arguments.Settings.CaseInsensitive ? BindingFlags.IgnoreCase : BindingFlags.Default;
+			_memberFilterCase = arguments.Settings.CaseInsensitive ? Type.FilterNameIgnoreCase : Type.FilterName;
+		}
+
+		public static Expression CreateLiteral(object value)
+		{
+			var expr = Expression.Constant(value);
+
+			return expr;
+		}
+
+		public static Expression GenerateConditional(Expression test, Expression expr1, Expression expr2, int errorPos)
+		{
+			if (test.Type != typeof(bool))
+				throw ParseException.Create(errorPos, ErrorMessages.FirstExprMustBeBool);
+			if (expr1.Type != expr2.Type)
+			{
+				var expr1As2 = expr2 != ParserConstants.NullLiteralExpression ? PromoteExpression(expr1, expr2.Type, true) : null;
+				var expr2As1 = expr1 != ParserConstants.NullLiteralExpression ? PromoteExpression(expr2, expr1.Type, true) : null;
+				if (expr1As2 != null && expr2As1 == null)
+				{
+					expr1 = expr1As2;
+				}
+				else if (expr2As1 != null && expr1As2 == null)
+				{
+					expr2 = expr2As1;
+				}
+				else
+				{
+					var type1 = expr1 != ParserConstants.NullLiteralExpression ? expr1.Type.Name : "null";
+					var type2 = expr2 != ParserConstants.NullLiteralExpression ? expr2.Type.Name : "null";
+					if (expr1As2 != null)
+						throw ParseException.Create(errorPos, ErrorMessages.BothTypesConvertToOther, type1, type2);
+
+					throw ParseException.Create(errorPos, ErrorMessages.NeitherTypeConvertsToOther, type1, type2);
+				}
+			}
+			return Expression.Condition(test, expr1, expr2);
+		}
+
+		public static Expression GenerateConversion(Expression expr, Type type, int errorPos)
+		{
+			var exprType = expr.Type;
+			if (exprType == type)
+			{
+				return expr;
+			}
+
+			//if (exprType.IsValueType && type.IsValueType)
+			//{
+			//	if ((IsNullableType(exprType) || IsNullableType(type)) &&
+			//			GetNonNullableType(exprType) == GetNonNullableType(type))
+			//		return Expression.Convert(expr, type);
+			//	if ((IsNumericType(exprType) || IsEnumType(exprType)) &&
+			//			(IsNumericType(type)) || IsEnumType(type))
+			//		return Expression.ConvertChecked(expr, type);
+			//}
+
+			//if (exprType.IsAssignableFrom(type) || type.IsAssignableFrom(exprType) ||
+			//				exprType.IsInterface || type.IsInterface)
+			//{
+			//	return Expression.Convert(expr, type);
+			//}
+
+			try
+			{
+				return Expression.ConvertChecked(expr, type);
+			}
+			catch (InvalidOperationException)
+			{
+				throw ParseException.Create(errorPos, ErrorMessages.CannotConvertValue,
+					Types.GetTypeName(exprType), Types.GetTypeName(type));
+			}
+		}
+
+		public static Expression GenerateDynamicProperty(Type type, Expression instance, string propertyOrFieldName)
+		{
+#if NETSTANDARD2_0
+			throw new NotImplementedException("Dynamic types are not supported in .NET Standard build");
+#else
+			var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
+				Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
+				propertyOrFieldName,
+				type,
+				new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null) }
+				);
+
+			return Expression.Dynamic(binder, typeof(object), instance);
+#endif
+		}
+
+		public static Expression GenerateDynamicMethodInvocation(Type type, Expression instance, string methodName, Expression[] args)
+		{
+#if NETSTANDARD2_0
+			throw new NotImplementedException("Dynamic types are not supported in .NET Standard build");
+#else
+			var argsDynamic = args.ToList();
+			argsDynamic.Insert(0, instance);
+			var binderM = Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
+				Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
+				methodName,
+				null,
+				type,
+				argsDynamic.Select(x => Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null))
+				);
+
+			return Expression.Dynamic(binderM, typeof(object), argsDynamic);
+#endif
+		}
+
+		public static bool IsDynamicExpression(Expression instance)
+		{
+			return instance != null && instance.NodeType == ExpressionType.Dynamic;
+		}
+
+		public void CheckAndPromoteOperand(Type signatures, ref Expression expr)
+		{
+			var args = new[] { expr };
+
+			args = PrepareOperandArguments(signatures, args);
+
+			expr = args[0];
+		}
+
+		public void CheckAndPromoteOperands(Type signatures, ref Expression left, ref Expression right)
+		{
+			var args = new[] { left, right };
+
+			args = PrepareOperandArguments(signatures, args);
+
+			left = args[0];
+			right = args[1];
+		}
+
+		private Expression[] PrepareOperandArguments(Type signatures, Expression[] args)
+		{
+			var applicableMethods = FindMethods(signatures, "F", false, args);
+			if (applicableMethods.Length == 1)
+				return applicableMethods[0].PromotedParameters;
+
+			return args;
+		}
+
+		private MemberInfo FindPropertyOrField(Type type, string memberName, bool staticAccess)
+		{
+			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
+					(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
+
+			foreach (var t in Types.SelfAndBaseTypes(type))
+			{
+				var members = t.FindMembers(MemberTypes.Property | MemberTypes.Field, flags, _memberFilterCase, memberName);
+				if (members.Length != 0)
+					return members[0];
+			}
+			return null;
+		}
+
+		public Expression GeneratePropertyOrFieldExpression(Type type, Expression instance, int errorPos, string propertyOrFieldName)
+		{
+			var member = FindPropertyOrField(type, propertyOrFieldName, instance == null);
+			if (member != null)
+			{
+				return member is PropertyInfo ?
+						Expression.Property(instance, (PropertyInfo)member) :
+						Expression.Field(instance, (FieldInfo)member);
+			}
+
+			if (Types.IsDynamicType(type) || Expressions.IsDynamicExpression(instance))
+				return Expressions.GenerateDynamicProperty(type, instance, propertyOrFieldName);
+
+			throw ParseException.Create(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, Types.GetTypeName(type));
+		}
+
+		public bool PrepareDelegateInvoke(Type type, ref Expression[] args)
+		{
+			var applicableMethods = FindMethods(type, "Invoke", false, args);
+			if (applicableMethods.Length != 1)
+				return false;
+
+			args = applicableMethods[0].PromotedParameters;
+
+			return true;
+		}
+
+		public MethodData[] FindMethods(Type type, string methodName, bool staticAccess, Expression[] args)
+		{
+			//var exactMethod = type.GetMethod(methodName, args.Select(p => p.Type).ToArray());
+			//if (exactMethod != null)
+			//{
+			//	return new MethodData[] { new MethodData(){ MethodBase = exactMethod, Parameters = exactMethod.GetParameters(), PromotedParameters = args} };
+			//}
+
+			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
+					(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
+			foreach (var t in Types.SelfAndBaseTypes(type))
+			{
+				var members = t.FindMembers(MemberTypes.Method, flags, _memberFilterCase, methodName);
+				var applicableMethods = FindBestMethod(members.Cast<MethodBase>(), args);
+
+				if (applicableMethods.Length > 0)
+					return applicableMethods;
+			}
+
+			return new MethodData[0];
+		}
+
+		public static MethodData[] FindIndexer(Type type, Expression[] args)
+		{
+			foreach (var t in Types.SelfAndBaseTypes(type))
+			{
+				MemberInfo[] members = t.GetDefaultMembers();
+				if (members.Length != 0)
+				{
+					IEnumerable<MethodData> methods = members.
+							OfType<PropertyInfo>().
+							Select(p => (MethodData) new IndexerData(p));
+
+					var applicableMethods = FindBestMethod(methods, args);
+					if (applicableMethods.Length > 0)
+						return applicableMethods;
+				}
+			}
+
+			return new MethodData[0];
+		}
+
+		public static MethodData[] FindBestMethod(IEnumerable<MethodBase> methods, Expression[] args)
+		{
+			return FindBestMethod(methods.Select(MethodData.Gen), args);
+		}
+
+		private static MethodData[] FindBestMethod(IEnumerable<MethodData> methods, Expression[] args)
+		{
+			var applicable = methods.
+					Where(m => CheckIfMethodIsApplicableAndPrepareIt(m, args)).
+					ToArray();
+			if (applicable.Length > 1)
+			{
+				return applicable.
+						Where(m => applicable.All(n => m == n || MethodHasPriority(args, m, n))).
+						ToArray();
+			}
+
+			return applicable;
+		}
+
+		private static bool CheckIfMethodIsApplicableAndPrepareIt(MethodData method, Expression[] args)
+		{
+			if (method.Parameters.Count(y => !y.HasDefaultValue) > args.Length)
+				return false;
+
+			var promotedArgs = new List<Expression>();
+			var declaredWorkingParameters = 0;
+
+			Type paramsArrayTypeFound = null;
+			List<Expression> paramsArrayPromotedArgument = null;
+
+			foreach (var currentArgument in args)
+			{
+				Type parameterType;
+
+				if (paramsArrayTypeFound != null)
+				{
+					parameterType = paramsArrayTypeFound;
+				}
+				else
+				{
+					if (declaredWorkingParameters >= method.Parameters.Length)
+					{
+						return false;
+					}
+
+					var parameterDeclaration = method.Parameters[declaredWorkingParameters];
+					if (parameterDeclaration.IsOut)
+					{
+						return false;
+					}
+
+					parameterType = parameterDeclaration.ParameterType;
+
+					if (HasParamsArrayType(parameterDeclaration))
+					{
+						paramsArrayTypeFound = parameterType;
+					}
+
+					declaredWorkingParameters++;
+				}
+
+				if (paramsArrayPromotedArgument == null)
+				{
+					if (parameterType.IsGenericParameter)
+					{
+						promotedArgs.Add(currentArgument);
+						continue;
+					}
+
+					var promoted = PromoteExpression(currentArgument, parameterType, true);
+					if (promoted != null)
+					{
+						promotedArgs.Add(promoted);
+						continue;
+					}
+				}
+
+				if (paramsArrayTypeFound != null)
+				{
+					var promoted = PromoteExpression(currentArgument, paramsArrayTypeFound.GetElementType(), true);
+					if (promoted != null)
+					{
+						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();
+						paramsArrayPromotedArgument.Add(promoted);
+						continue;
+					}
+				}
+
+				return false;
+			}
+
+			if (paramsArrayPromotedArgument != null)
+			{
+				method.HasParamsArray = true;
+				var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
+				if (paramsArrayElementType == null)
+					throw new Exception("Type is not an array, element not found");
+				promotedArgs.Add(Expression.NewArrayInit(paramsArrayElementType, paramsArrayPromotedArgument));
+			}
+
+			// Add default params, if needed.
+			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select(x => Expression.Constant(x.DefaultValue, x.ParameterType)));
+
+			method.PromotedParameters = promotedArgs.ToArray();
+
+			if (method.MethodBase != null && method.MethodBase.IsGenericMethodDefinition &&
+					method.MethodBase is MethodInfo)
+			{
+				var methodInfo = (MethodInfo)method.MethodBase;
+
+				var actualGenericArgs = ExtractActualGenericArguments(
+					method.Parameters.Select(p => p.ParameterType).ToArray(),
+					method.PromotedParameters.Select(p => p.Type).ToArray());
+
+				var genericArgs = methodInfo.GetGenericArguments()
+					.Select(p => actualGenericArgs[p.Name])
+					.ToArray();
+
+				method.MethodBase = methodInfo.MakeGenericMethod(genericArgs);
+			}
+
+			return true;
+		}
+
+		private static Dictionary<string, Type> ExtractActualGenericArguments(
+			Type[] methodGenericParameters,
+			Type[] methodActualParameters)
+		{
+			var extractedGenericTypes = new Dictionary<string, Type>();
+
+			for (var i = 0; i < methodGenericParameters.Length; i++)
+			{
+				var requestedType = methodGenericParameters[i];
+				var actualType = methodActualParameters[i];
+
+				if (requestedType.IsGenericParameter)
+				{
+					extractedGenericTypes[requestedType.Name] = actualType;
+				}
+				else if (requestedType.ContainsGenericParameters)
+				{
+					var innerGenericTypes = ExtractActualGenericArguments(requestedType.GetGenericArguments(), actualType.GetGenericArguments());
+
+					foreach (var innerGenericType in innerGenericTypes)
+						extractedGenericTypes[innerGenericType.Key] = innerGenericType.Value;
+				}
+			}
+
+			return extractedGenericTypes;
+		}
+
+		public static Expression PromoteExpression(Expression expr, Type type, bool exact)
+		{
+			if (expr.Type == type) return expr;
+			if (expr is ConstantExpression)
+			{
+				var ce = (ConstantExpression)expr;
+				if (ce == ParserConstants.NullLiteralExpression)
+				{
+					if (!type.IsValueType || Types.IsNullableType(type))
+						return Expression.Constant(null, type);
+				}
+			}
+
+			if (type.IsGenericType && !Types.IsNumericType(type))
+			{
+				var genericType = FindAssignableGenericType(expr.Type, type.GetGenericTypeDefinition());
+				if (genericType != null)
+					return Expression.Convert(expr, genericType);
+			}
+
+			if (Types.IsCompatibleWith(expr.Type, type))
+			{
+				if (type.IsValueType || exact)
+				{
+					return Expression.Convert(expr, type);
+				}
+				return expr;
+			}
+
+			return null;
+		}
+
+		public static bool IsWritable(Expression expression)
+		{
+			switch (expression.NodeType)
+			{
+				case ExpressionType.Index:
+					PropertyInfo indexer = ((IndexExpression)expression).Indexer;
+					return indexer == null || indexer.CanWrite;
+				case ExpressionType.MemberAccess:
+					MemberInfo member = ((MemberExpression)expression).Member;
+					var prop = member as PropertyInfo;
+					if (prop != null)
+						return prop.CanWrite;
+					else
+					{
+						var field = (FieldInfo)member;
+						return !(field.IsInitOnly || field.IsLiteral);
+					}
+				case ExpressionType.Parameter:
+					return true;
+			}
+
+			return false;
+		}
+
+		// from http://stackoverflow.com/a/1075059/209727
+		private static Type FindAssignableGenericType(Type givenType, Type genericTypeDefinition)
+		{
+			var interfaceTypes = givenType.GetInterfaces();
+
+			foreach (var it in interfaceTypes)
+			{
+				if (it.IsGenericType && it.GetGenericTypeDefinition() == genericTypeDefinition)
+				{
+					return it;
+				}
+			}
+
+			if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericTypeDefinition)
+				return givenType;
+
+			var baseType = givenType.BaseType;
+			if (baseType == null)
+				return null;
+
+			return FindAssignableGenericType(baseType, genericTypeDefinition);
+		}
+
+		private static bool HasParamsArrayType(ParameterInfo parameterInfo)
+		{
+			return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
+		}
+
+		private static Type GetParameterType(ParameterInfo parameterInfo)
+		{
+			var isParamsArray = HasParamsArrayType(parameterInfo);
+			var type = isParamsArray
+				? parameterInfo.ParameterType.GetElementType()
+				: parameterInfo.ParameterType;
+			return type;
+		}
+
+		private static bool MethodHasPriority(Expression[] args, MethodData method, MethodData otherMethod)
+		{
+			if (method.HasParamsArray == false && otherMethod.HasParamsArray)
+				return true;
+			if (method.HasParamsArray && otherMethod.HasParamsArray == false)
+				return false;
+
+			//if (m1.Parameters.Length > m2.Parameters.Length)
+			//	return true;
+			//else if (m1.Parameters.Length < m2.Parameters.Length)
+			//	return false;
+
+			var better = false;
+			for (var i = 0; i < args.Length; i++)
+			{
+				var methodParam = method.Parameters[i];
+				var otherMethodParam = otherMethod.Parameters[i];
+				var methodParamType = GetParameterType(methodParam);
+				var otherMethodParamType = GetParameterType(otherMethodParam);
+				var c = Types.CompareConversions(args[i].Type, methodParamType, otherMethodParamType);
+				if (c < 0)
+					return false;
+				if (c > 0)
+					better = true;
+				if (HasParamsArrayType(methodParam) || HasParamsArrayType(otherMethodParam))
+					break;
+			}
+			return better;
+		}
+
+		public static Expression GenerateEqual(Expression left, Expression right)
+		{
+			return Expression.Equal(left, right);
+		}
+
+		public static Expression GenerateNotEqual(Expression left, Expression right)
+		{
+			return Expression.NotEqual(left, right);
+		}
+
+		public static Expression GenerateGreaterThan(Expression left, Expression right)
+		{
+			if (left.Type == typeof(string))
+			{
+				return Expression.GreaterThan(
+						GenerateStaticMethodCall("Compare", left, right),
+						Expression.Constant(0)
+				);
+			}
+			return Expression.GreaterThan(left, right);
+		}
+
+		public static Expression GenerateGreaterThanEqual(Expression left, Expression right)
+		{
+			if (left.Type == typeof(string))
+			{
+				return Expression.GreaterThanOrEqual(
+						GenerateStaticMethodCall("Compare", left, right),
+						Expression.Constant(0)
+				);
+			}
+			return Expression.GreaterThanOrEqual(left, right);
+		}
+
+		public static Expression GenerateLessThan(Expression left, Expression right)
+		{
+			if (left.Type == typeof(string))
+			{
+				return Expression.LessThan(
+						GenerateStaticMethodCall("Compare", left, right),
+						Expression.Constant(0)
+				);
+			}
+			return Expression.LessThan(left, right);
+		}
+
+		public static Expression GenerateLessThanEqual(Expression left, Expression right)
+		{
+			if (left.Type == typeof(string))
+			{
+				return Expression.LessThanOrEqual(
+						GenerateStaticMethodCall("Compare", left, right),
+						Expression.Constant(0)
+				);
+			}
+			return Expression.LessThanOrEqual(left, right);
+		}
+
+		public static Expression GenerateAdd(Expression left, Expression right)
+		{
+			return Expression.Add(left, right);
+		}
+
+		public static Expression GenerateSubtract(Expression left, Expression right)
+		{
+			return Expression.Subtract(left, right);
+		}
+
+		public static Expression GenerateStringConcat(Expression left, Expression right)
+		{
+			var concatMethod = typeof(string).GetMethod("Concat", new[] { typeof(object), typeof(object) });
+			if (concatMethod == null)
+				throw new Exception("String concat method not found");
+
+			var rightObj =
+				right.Type.IsValueType
+				? Expression.ConvertChecked(right, typeof(object))
+				: right;
+			var leftObj =
+				left.Type.IsValueType
+				? Expression.ConvertChecked(left, typeof(object))
+				: left;
+
+			return Expression.Call(
+					null,
+					concatMethod,
+					new[] { leftObj, rightObj });
+		}
+
+		private static MethodInfo GetStaticMethod(string methodName, Expression left, Expression right)
+		{
+			return left.Type.GetMethod(methodName, new[] { left.Type, right.Type });
+		}
+
+		private static Expression GenerateStaticMethodCall(string methodName, Expression left, Expression right)
+		{
+			return Expression.Call(null, GetStaticMethod(methodName, left, right), new[] { left, right });
+		}
+
+		internal class MethodData
+		{
+			public MethodBase MethodBase;
+			public ParameterInfo[] Parameters;
+			public Expression[] PromotedParameters;
+			public bool HasParamsArray;
+
+			public static MethodData Gen(MethodBase method)
+			{
+				return new MethodData
+				{
+					MethodBase = method,
+					Parameters = method.GetParameters()
+				};
+			}
+		}
+
+		internal class IndexerData : MethodData
+		{
+			public readonly PropertyInfo Indexer;
+
+			public IndexerData(PropertyInfo indexer)
+			{
+				Indexer = indexer;
+
+				var method = indexer.GetGetMethod();
+				if (method != null)
+				{
+					Parameters = method.GetParameters();
+				}
+				else
+				{
+					method = indexer.GetSetMethod();
+					Parameters = RemoveLast(method.GetParameters());
+				}
+			}
+
+			private static T[] RemoveLast<T>(T[] array)
+			{
+				T[] result = new T[array.Length - 1];
+				Array.Copy(array, 0, result, 0, result.Length);
+				return result;
+			}
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -40,15 +39,12 @@ namespace DynamicExpresso.Parsing
 		private char _parseChar;
 		private Token _token;
 
-		private readonly BindingFlags _bindingCase;
-		private readonly MemberFilter _memberFilterCase;
+		private readonly Expressions _expressions;
 
 		private Parser(ParserArguments arguments)
 		{
 			_arguments = arguments;
-
-			_bindingCase = arguments.Settings.CaseInsensitive ? BindingFlags.IgnoreCase : BindingFlags.Default;
-			_memberFilterCase = arguments.Settings.CaseInsensitive ? Type.FilterNameIgnoreCase : Type.FilterName;
+			_expressions = new Expressions(_arguments);
 
 			_expressionText = arguments.ExpressionText ?? string.Empty;
 			_expressionTextLength = _expressionText.Length;
@@ -71,7 +67,7 @@ namespace DynamicExpresso.Parsing
 
 			if (returnType != typeof(void))
 			{
-				return GenerateConversion(expression, returnType, errorPos);
+				return Expressions.GenerateConversion(expression, returnType, errorPos);
 			}
 
 			return expression;
@@ -95,16 +91,16 @@ namespace DynamicExpresso.Parsing
 				if (!_arguments.Settings.AssignmentOperators.HasFlag(AssignmentOperators.AssignmentEqual))
 					throw new AssignmentOperatorDisabledException("=", _token.pos);
 
-				if (!IsWritable(left))
-					throw CreateParseException(_token.pos, ErrorMessages.ExpressionMustBeWritable);
+				if (!Expressions.IsWritable(left))
+					throw ParseException.Create(_token.pos, ErrorMessages.ExpressionMustBeWritable);
 
 				NextToken();
 
 				var right = ParseAssignment();
-				var promoted = PromoteExpression(right, left.Type, true);
+				var promoted = Expressions.PromoteExpression(right, left.Type, true);
 				if (promoted == null)
-					throw CreateParseException(_token.pos, ErrorMessages.CannotConvertValue,
-						GetTypeName(right.Type), GetTypeName(left.Type));
+					throw ParseException.Create(_token.pos, ErrorMessages.CannotConvertValue,
+						Types.GetTypeName(right.Type), Types.GetTypeName(left.Type));
 
 				left = Expression.Assign(left, promoted);
 			}
@@ -120,7 +116,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var exprRight = ParseExpressionSegment();
-				expr = GenerateConditional(GenerateEqual(expr, ParserConstants.NullLiteralExpression), exprRight, expr, errorPos);
+				expr = Expressions.GenerateConditional(Expressions.GenerateEqual(expr, ParserConstants.NullLiteralExpression), exprRight, expr, errorPos);
 			}
 			else if (_token.id == TokenId.Question)
 			{
@@ -129,7 +125,7 @@ namespace DynamicExpresso.Parsing
 				ValidateToken(TokenId.Colon, ErrorMessages.ColonExpected);
 				NextToken();
 				var expr2 = ParseExpressionSegment();
-				expr = GenerateConditional(expr, expr1, expr2, errorPos);
+				expr = Expressions.GenerateConditional(expr, expr1, expr2, errorPos);
 			}
 			return expr;
 		}
@@ -142,7 +138,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var right = ParseConditionalAnd();
-				CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
+				_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
 				left = Expression.OrElse(left, right);
 			}
 			return left;
@@ -156,7 +152,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var right = ParseLogicalOr();
-				CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
+				_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
 				left = Expression.AndAlso(left, right);
 			}
 			return left;
@@ -170,7 +166,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var right = ParseLogicalXor();
-				CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
+				_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
 				left = Expression.Or(left, right);
 			}
 			return left;
@@ -184,7 +180,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var right = ParseLogicalAnd();
-				CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
+				_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
 				left = Expression.ExclusiveOr(left, right);
 			}
 			return left;
@@ -198,7 +194,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var right = ParseComparison();
-				CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
+				_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.ILogicalSignatures), ref left, ref right);
 				left = Expression.And(left, right);
 			}
 			return left;
@@ -231,7 +227,7 @@ namespace DynamicExpresso.Parsing
 				//		}
 				//		else
 				//		{
-				//			throw CreateParseException(op.pos, ErrorMessages.IncompatibleOperands,
+				//			throw ParseException.Create(op.pos, ErrorMessages.IncompatibleOperands,
 				//				op.text, GetTypeName(left.Type), GetTypeName(right.Type));
 				//		}
 				//	}
@@ -251,7 +247,7 @@ namespace DynamicExpresso.Parsing
 				//		}
 				//		else
 				//		{
-				//			throw CreateParseException(op.pos, ErrorMessages.IncompatibleOperands,
+				//			throw ParseException.Create(op.pos, ErrorMessages.IncompatibleOperands,
 				//				op.text, GetTypeName(left.Type), GetTypeName(right.Type));
 				//		}
 				//	}
@@ -262,7 +258,7 @@ namespace DynamicExpresso.Parsing
 				//			op.text, ref left, ref right, op.pos);
 				//}
 
-				CheckAndPromoteOperands(
+				_expressions.CheckAndPromoteOperands(
 					isEquality ? typeof(ParseSignatures.IEqualitySignatures) : typeof(ParseSignatures.IRelationalSignatures),
 					ref left,
 					ref right);
@@ -270,22 +266,22 @@ namespace DynamicExpresso.Parsing
 				switch (op.id)
 				{
 					case TokenId.DoubleEqual:
-						left = GenerateEqual(left, right);
+						left = Expressions.GenerateEqual(left, right);
 						break;
 					case TokenId.ExclamationEqual:
-						left = GenerateNotEqual(left, right);
+						left = Expressions.GenerateNotEqual(left, right);
 						break;
 					case TokenId.GreaterThan:
-						left = GenerateGreaterThan(left, right);
+						left = Expressions.GenerateGreaterThan(left, right);
 						break;
 					case TokenId.GreaterThanEqual:
-						left = GenerateGreaterThanEqual(left, right);
+						left = Expressions.GenerateGreaterThanEqual(left, right);
 						break;
 					case TokenId.LessThan:
-						left = GenerateLessThan(left, right);
+						left = Expressions.GenerateLessThan(left, right);
 						break;
 					case TokenId.LessThanEqual:
-						left = GenerateLessThanEqual(left, right);
+						left = Expressions.GenerateLessThanEqual(left, right);
 						break;
 				}
 			}
@@ -306,14 +302,14 @@ namespace DynamicExpresso.Parsing
 
 				Type knownType;
 				if (!_arguments.TryGetKnownType(_token.text, out knownType))
-					throw CreateParseException(op.pos, ErrorMessages.TypeIdentifierExpected);
+					throw ParseException.Create(op.pos, ErrorMessages.TypeIdentifierExpected);
 
 				if (typeOperator == ParserConstants.KeywordIs)
 					left = Expression.TypeIs(left, knownType);
 				else if (typeOperator == ParserConstants.KeywordAs)
 					left = Expression.TypeAs(left, knownType);
 				else
-					throw CreateParseException(_token.pos, ErrorMessages.SyntaxError);
+					throw ParseException.Create(_token.pos, ErrorMessages.SyntaxError);
 
 				NextToken();
 			}
@@ -335,17 +331,17 @@ namespace DynamicExpresso.Parsing
 					case TokenId.Plus:
 						if (left.Type == typeof(string) || right.Type == typeof(string))
 						{
-							left = GenerateStringConcat(left, right);
+							left = Expressions.GenerateStringConcat(left, right);
 						}
 						else
 						{
-							CheckAndPromoteOperands(typeof(ParseSignatures.IAddSignatures), ref left, ref right);
-							left = GenerateAdd(left, right);
+							_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.IAddSignatures), ref left, ref right);
+							left = Expressions.GenerateAdd(left, right);
 						}
 						break;
 					case TokenId.Minus:
-						CheckAndPromoteOperands(typeof(ParseSignatures.ISubtractSignatures), ref left, ref right);
-						left = GenerateSubtract(left, right);
+						_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.ISubtractSignatures), ref left, ref right);
+						left = Expressions.GenerateSubtract(left, right);
 						break;
 				}
 			}
@@ -363,7 +359,7 @@ namespace DynamicExpresso.Parsing
 				NextToken();
 				var right = ParseUnary();
 
-				CheckAndPromoteOperands(typeof(ParseSignatures.IArithmeticSignatures), ref left, ref right);
+				_expressions.CheckAndPromoteOperands(typeof(ParseSignatures.IArithmeticSignatures), ref left, ref right);
 
 				switch (op.id)
 				{
@@ -408,7 +404,7 @@ namespace DynamicExpresso.Parsing
 				var expr = ParseUnary();
 				if (op.id == TokenId.Minus)
 				{
-					CheckAndPromoteOperand(typeof(ParseSignatures.INegationSignatures), ref expr);
+					_expressions.CheckAndPromoteOperand(typeof(ParseSignatures.INegationSignatures), ref expr);
 					expr = Expression.Negate(expr);
 				}
 				else if (op.id == TokenId.Plus)
@@ -417,7 +413,7 @@ namespace DynamicExpresso.Parsing
 				}
 				else if (op.id == TokenId.Exclamation)
 				{
-					CheckAndPromoteOperand(typeof(ParseSignatures.INotSignatures), ref expr);
+					_expressions.CheckAndPromoteOperand(typeof(ParseSignatures.INotSignatures), ref expr);
 					expr = Expression.Not(expr);
 				}
 				return expr;
@@ -439,7 +435,7 @@ namespace DynamicExpresso.Parsing
 				else if(_token.id == TokenId.QuestionDot)
 				{
 					NextToken();
-					expr = GenerateConditional(GenerateEqual(expr, ParserConstants.NullLiteralExpression), ParserConstants.NullLiteralExpression, ParseMemberAccess(null, expr), _token.pos);
+					expr = Expressions.GenerateConditional(Expressions.GenerateEqual(expr, ParserConstants.NullLiteralExpression), ParserConstants.NullLiteralExpression, ParseMemberAccess(null, expr), _token.pos);
 				}
 				else if (_token.id == TokenId.OpenBracket)
 				{
@@ -454,7 +450,7 @@ namespace DynamicExpresso.Parsing
 					if (typeof(Delegate).IsAssignableFrom(expr.Type))
 						expr = ParseDelegateInvocation(expr, tokenPos);
 					else
-						throw CreateParseException(tokenPos, ErrorMessages.InvalidMethodCall, GetTypeName(expr.Type));
+						throw ParseException.Create(tokenPos, ErrorMessages.InvalidMethodCall, Types.GetTypeName(expr.Type));
 				}
 				else
 				{
@@ -483,7 +479,7 @@ namespace DynamicExpresso.Parsing
 				case TokenId.End:
 					return Expression.Empty();
 				default:
-					throw CreateParseException(_token.pos, ErrorMessages.ExpressionExpected);
+					throw ParseException.Create(_token.pos, ErrorMessages.ExpressionExpected);
 			}
 		}
 
@@ -495,10 +491,10 @@ namespace DynamicExpresso.Parsing
 			s = EvalEscapeStringLiteral(s);
 
 			if (s.Length != 1)
-				throw CreateParseException(_token.pos, ErrorMessages.InvalidCharacterLiteral);
+				throw ParseException.Create(_token.pos, ErrorMessages.InvalidCharacterLiteral);
 
 			NextToken();
-			return CreateLiteral(s[0]);
+			return Expressions.CreateLiteral(s[0]);
 		}
 
 		private Expression ParseStringLiteral()
@@ -519,7 +515,7 @@ namespace DynamicExpresso.Parsing
 			//}
 
 			NextToken();
-			return CreateLiteral(s);
+			return Expressions.CreateLiteral(s);
 		}
 
 		private string EvalEscapeStringLiteral(string source)
@@ -532,7 +528,7 @@ namespace DynamicExpresso.Parsing
 				if (c == '\\')
 				{
 					if ((i + 1) == source.Length)
-						throw CreateParseException(_token.pos, ErrorMessages.InvalidEscapeSequence);
+						throw ParseException.Create(_token.pos, ErrorMessages.InvalidEscapeSequence);
 
 					builder.Append(EvalEscapeChar(source[++i]));
 				}
@@ -570,7 +566,7 @@ namespace DynamicExpresso.Parsing
 				case 'v':
 					return '\v';
 				default:
-					throw CreateParseException(_token.pos, ErrorMessages.InvalidEscapeSequence);
+					throw ParseException.Create(_token.pos, ErrorMessages.InvalidEscapeSequence);
 			}
 		}
 
@@ -581,30 +577,30 @@ namespace DynamicExpresso.Parsing
 			if (text[0] != '-')
 			{
 				if (!ulong.TryParse(text, ParseLiteralUnsignedNumberStyle, ParseCulture, out ulong value))
-					throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+					throw ParseException.Create(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
 
 				NextToken();
 
 				if (value <= int.MaxValue)
-					return CreateLiteral((int)value);
+					return Expressions.CreateLiteral((int)value);
 				if (value <= uint.MaxValue)
-					return CreateLiteral((uint)value);
+					return Expressions.CreateLiteral((uint)value);
 				if (value <= long.MaxValue)
-					return CreateLiteral((long)value);
+					return Expressions.CreateLiteral((long)value);
 
-				return CreateLiteral(value);
+				return Expressions.CreateLiteral(value);
 			}
 			else
 			{
 				if (!long.TryParse(text, ParseLiteralNumberStyle, ParseCulture, out long value))
-					throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+					throw ParseException.Create(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
 
 				NextToken();
 
 				if (value >= int.MinValue && value <= int.MaxValue)
-					return CreateLiteral((int)value);
+					return Expressions.CreateLiteral((int)value);
 
-				return CreateLiteral(value);
+				return Expressions.CreateLiteral(value);
 			}
 		}
 
@@ -632,18 +628,11 @@ namespace DynamicExpresso.Parsing
 			}
 
 			if (value == null)
-				throw CreateParseException(_token.pos, ErrorMessages.InvalidRealLiteral, text);
+				throw ParseException.Create(_token.pos, ErrorMessages.InvalidRealLiteral, text);
 
 			NextToken();
 
-			return CreateLiteral(value);
-		}
-
-		private static Expression CreateLiteral(object value)
-		{
-			var expr = Expression.Constant(value);
-
-			return expr;
+			return Expressions.CreateLiteral(value);
 		}
 
 		private Expression ParseParenExpression()
@@ -729,42 +718,13 @@ namespace DynamicExpresso.Parsing
 			NextToken();
 			var args = ParseArgumentList();
 			if (args.Length != 1)
-				throw CreateParseException(errorPos, ErrorMessages.TypeofRequiresOneArg);
+				throw ParseException.Create(errorPos, ErrorMessages.TypeofRequiresOneArg);
 
 			var constExp = args[0] as ConstantExpression;
 			if (constExp == null || !(constExp.Value is Type))
-				throw CreateParseException(errorPos, ErrorMessages.TypeofRequiresAType);
+				throw ParseException.Create(errorPos, ErrorMessages.TypeofRequiresAType);
 
 			return constExp;
-		}
-
-		private Expression GenerateConditional(Expression test, Expression expr1, Expression expr2, int errorPos)
-		{
-			if (test.Type != typeof(bool))
-				throw CreateParseException(errorPos, ErrorMessages.FirstExprMustBeBool);
-			if (expr1.Type != expr2.Type)
-			{
-				var expr1As2 = expr2 != ParserConstants.NullLiteralExpression ? PromoteExpression(expr1, expr2.Type, true) : null;
-				var expr2As1 = expr1 != ParserConstants.NullLiteralExpression ? PromoteExpression(expr2, expr1.Type, true) : null;
-				if (expr1As2 != null && expr2As1 == null)
-				{
-					expr1 = expr1As2;
-				}
-				else if (expr2As1 != null && expr1As2 == null)
-				{
-					expr2 = expr2As1;
-				}
-				else
-				{
-					var type1 = expr1 != ParserConstants.NullLiteralExpression ? expr1.Type.Name : "null";
-					var type2 = expr2 != ParserConstants.NullLiteralExpression ? expr2.Type.Name : "null";
-					if (expr1As2 != null)
-						throw CreateParseException(errorPos, ErrorMessages.BothTypesConvertToOther, type1, type2);
-
-					throw CreateParseException(errorPos, ErrorMessages.NeitherTypeConvertsToOther, type1, type2);
-				}
-			}
-			return Expression.Condition(test, expr1, expr2);
 		}
 
 		private Expression ParseNew()
@@ -781,7 +741,7 @@ namespace DynamicExpresso.Parsing
 
 			var constructor = newType.GetConstructor(args.Select(p => p.Type).ToArray());
 			if (constructor == null)
-				throw CreateParseException(_token.pos, ErrorMessages.NoApplicableConstructor, newType);
+				throw ParseException.Create(_token.pos, ErrorMessages.NoApplicableConstructor, newType);
 
 			return Expression.MemberInit(Expression.New(constructor, args));
 		}
@@ -790,8 +750,8 @@ namespace DynamicExpresso.Parsing
 		{
 			var args = ParseArgumentList();
 
-			if (!PrepareDelegateInvoke(lambda.Type, ref args))
-				throw CreateParseException(errorPos, ErrorMessages.ArgsIncompatibleWithLambda);
+			if (!_expressions.PrepareDelegateInvoke(lambda.Type, ref args))
+				throw ParseException.Create(errorPos, ErrorMessages.ArgsIncompatibleWithLambda);
 
 			return Expression.Invoke(lambda, args);
 		}
@@ -800,21 +760,10 @@ namespace DynamicExpresso.Parsing
 		{
 			var args = ParseArgumentList();
 
-			if (!PrepareDelegateInvoke(delegateExp.Type, ref args))
-				throw CreateParseException(errorPos, ErrorMessages.ArgsIncompatibleWithDelegate);
+			if (!_expressions.PrepareDelegateInvoke(delegateExp.Type, ref args))
+				throw ParseException.Create(errorPos, ErrorMessages.ArgsIncompatibleWithDelegate);
 
 			return Expression.Invoke(delegateExp, args);
-		}
-
-		private bool PrepareDelegateInvoke(Type type, ref Expression[] args)
-		{
-			var applicableMethods = FindMethods(type, "Invoke", false, args);
-			if (applicableMethods.Length != 1)
-				return false;
-
-			args = applicableMethods[0].PromotedParameters;
-
-			return true;
 		}
 
 		private Expression ParseTypeKeyword(Type type)
@@ -823,8 +772,8 @@ namespace DynamicExpresso.Parsing
 			NextToken();
 			if (_token.id == TokenId.Question)
 			{
-				if (!type.IsValueType || IsNullableType(type))
-					throw CreateParseException(errorPos, ErrorMessages.TypeHasNoNullableForm, GetTypeName(type));
+				if (!type.IsValueType || Types.IsNullableType(type))
+					throw ParseException.Create(errorPos, ErrorMessages.TypeHasNoNullableForm, Types.GetTypeName(type));
 				type = typeof(Nullable<>).MakeGenericType(type);
 				NextToken();
 			}
@@ -861,41 +810,6 @@ namespace DynamicExpresso.Parsing
 		//    }
 		//}
 
-		private Expression GenerateConversion(Expression expr, Type type, int errorPos)
-		{
-			var exprType = expr.Type;
-			if (exprType == type)
-			{
-				return expr;
-			}
-
-			//if (exprType.IsValueType && type.IsValueType)
-			//{
-			//	if ((IsNullableType(exprType) || IsNullableType(type)) &&
-			//			GetNonNullableType(exprType) == GetNonNullableType(type))
-			//		return Expression.Convert(expr, type);
-			//	if ((IsNumericType(exprType) || IsEnumType(exprType)) &&
-			//			(IsNumericType(type)) || IsEnumType(type))
-			//		return Expression.ConvertChecked(expr, type);
-			//}
-
-			//if (exprType.IsAssignableFrom(type) || type.IsAssignableFrom(exprType) ||
-			//				exprType.IsInterface || type.IsInterface)
-			//{
-			//	return Expression.Convert(expr, type);
-			//}
-
-			try
-			{
-				return Expression.ConvertChecked(expr, type);
-			}
-			catch (InvalidOperationException)
-			{
-				throw CreateParseException(errorPos, ErrorMessages.CannotConvertValue,
-						GetTypeName(exprType), GetTypeName(type));
-			}
-		}
-
 		private Expression ParseMemberAccess(Type type, Expression instance)
 		{
 			if (instance != null) type = instance.Type;
@@ -905,23 +819,7 @@ namespace DynamicExpresso.Parsing
 			if (_token.id == TokenId.OpenParen)
 				return ParseMethodInvocation(type, instance, errorPos, id);
 
-			return GeneratePropertyOrFieldExpression(type, instance, errorPos, id);
-		}
-
-		private Expression GeneratePropertyOrFieldExpression(Type type, Expression instance, int errorPos, string propertyOrFieldName)
-		{
-			var member = FindPropertyOrField(type, propertyOrFieldName, instance == null);
-			if (member != null)
-			{
-				return member is PropertyInfo ?
-						Expression.Property(instance, (PropertyInfo)member) :
-						Expression.Field(instance, (FieldInfo)member);
-			}
-
-			if (IsDynamicType(type) || IsDynamicExpression(instance))
-				return ParseDynamicProperty(type, instance, propertyOrFieldName);
-
-			throw CreateParseException(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(type));
+			return _expressions.GeneratePropertyOrFieldExpression(type, instance, errorPos, id);
 		}
 
 		private Expression ParseMethodInvocation(Type type, Expression instance, int errorPos, string methodName)
@@ -937,10 +835,10 @@ namespace DynamicExpresso.Parsing
 			if (methodInvocationExpression != null)
 				return methodInvocationExpression;
 
-			if (IsDynamicType(type) || IsDynamicExpression(instance))
-				return ParseDynamicMethodInvocation(type, instance, methodName, args);
+			if (Types.IsDynamicType(type) || Expressions.IsDynamicExpression(instance))
+				return Expressions.GenerateDynamicMethodInvocation(type, instance, methodName, args);
 
-			throw new NoApplicableMethodException(methodName, GetTypeName(type), errorPos);
+			throw new NoApplicableMethodException(methodName, Types.GetTypeName(type), errorPos);
 		}
 
 		private Expression ParseExtensionMethodInvocation(Type type, Expression instance, int errorPos, string id, Expression[] args)
@@ -949,9 +847,10 @@ namespace DynamicExpresso.Parsing
 			extensionMethodsArguments[0] = instance;
 			args.CopyTo(extensionMethodsArguments, 1);
 
-			var extensionMethods = FindExtensionMethods(id, extensionMethodsArguments);
+			var matchMethods = _arguments.GetExtensionMethods(id);
+			var extensionMethods = Expressions.FindBestMethod(matchMethods, extensionMethodsArguments);
 			if (extensionMethods.Length > 1)
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, Types.GetTypeName(type));
 
 			if (extensionMethods.Length == 1)
 			{
@@ -967,9 +866,9 @@ namespace DynamicExpresso.Parsing
 
 		private Expression ParseNormalMethodInvocation(Type type, Expression instance, int errorPos, string id, Expression[] args)
 		{
-			var applicableMethods = FindMethods(type, id, instance == null, args);
+			var applicableMethods = _expressions.FindMethods(type, id, instance == null, args);
 			if (applicableMethods.Length > 1)
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, Types.GetTypeName(type));
 
 			if (applicableMethods.Length == 1)
 			{
@@ -980,24 +879,6 @@ namespace DynamicExpresso.Parsing
 
 			return null;
 		}
-
-		//static Type FindGenericType(Type generic, Type type)
-		//{
-		//	while (type != null && type != typeof(object))
-		//	{
-		//		if (type.IsGenericType && type.GetGenericTypeDefinition() == generic) return type;
-		//		if (generic.IsInterface)
-		//		{
-		//			foreach (Type intfType in type.GetInterfaces())
-		//			{
-		//				Type found = FindGenericType(generic, intfType);
-		//				if (found != null) return found;
-		//			}
-		//		}
-		//		type = type.BaseType;
-		//	}
-		//	return null;
-		//}
 
 		//Expression ParseAggregate(Expression instance, Type elementType, string methodName, int errorPos)
 		//{
@@ -1028,41 +909,6 @@ namespace DynamicExpresso.Parsing
 		//    }
 		//    return Expression.Call(typeof(Enumerable), signature.Name, typeArgs, args);
 		//}
-
-		private static Expression ParseDynamicProperty(Type type, Expression instance, string propertyOrFieldName)
-		{
-#if NETSTANDARD2_0
-			throw new NotImplementedException("Dynamic types are not supported in .NET Standard build");
-#else
-			var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
-				Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-				propertyOrFieldName,
-				type,
-				new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null) }
-				);
-
-			return Expression.Dynamic(binder, typeof(object), instance);
-#endif
-		}
-
-		private static Expression ParseDynamicMethodInvocation(Type type, Expression instance, string methodName, Expression[] args)
-		{
-#if NETSTANDARD2_0
-			throw new NotImplementedException("Dynamic types are not supported in .NET Standard build");
-#else
-			var argsDynamic = args.ToList();
-			argsDynamic.Insert(0, instance);
-			var binderM = Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
-				Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-				methodName,
-				null,
-				type,
-				argsDynamic.Select(x => Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null))
-				);
-
-			return Expression.Dynamic(binderM, typeof(object), argsDynamic);
-#endif
-		}
 
 		private Expression[] ParseArgumentList()
 		{
@@ -1097,764 +943,38 @@ namespace DynamicExpresso.Parsing
 			if (expr.Type.IsArray)
 			{
 				if (expr.Type.GetArrayRank() != args.Length)
-					throw CreateParseException(errorPos, ErrorMessages.IncorrectNumberOfIndexes);
+					throw ParseException.Create(errorPos, ErrorMessages.IncorrectNumberOfIndexes);
 
 				for (int i = 0; i < args.Length; i++)
 				{
-					args[i] = PromoteExpression(args[i], typeof(int), true);
+					args[i] = Expressions.PromoteExpression(args[i], typeof(int), true);
 					if (args[i] == null)
-						throw CreateParseException(errorPos, ErrorMessages.InvalidIndex);
+						throw ParseException.Create(errorPos, ErrorMessages.InvalidIndex);
 				}
 
 				return Expression.ArrayAccess(expr, args);
 			}
 
-			var applicableMethods = FindIndexer(expr.Type, args);
+			var applicableMethods = Expressions.FindIndexer(expr.Type, args);
 			if (applicableMethods.Length == 0)
 			{
-				throw CreateParseException(errorPos, ErrorMessages.NoApplicableIndexer,
-						GetTypeName(expr.Type));
+				throw ParseException.Create(errorPos, ErrorMessages.NoApplicableIndexer,
+						Types.GetTypeName(expr.Type));
 			}
 
 			if (applicableMethods.Length > 1)
 			{
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousIndexerInvocation,
-						GetTypeName(expr.Type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousIndexerInvocation,
+						Types.GetTypeName(expr.Type));
 			}
 
-			var indexer = (IndexerData) applicableMethods[0];
+			var indexer = (Expressions.IndexerData) applicableMethods[0];
 			return Expression.Property(expr, indexer.Indexer, indexer.PromotedParameters);
 		}
 
-		private static bool IsNullableType(Type type)
-		{
-			return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
-		}
-
-		private static bool IsDynamicType(Type type)
-		{
-			return typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type);
-		}
-
-		private static bool IsDynamicExpression(Expression instance)
-		{
-			return instance != null && instance.NodeType == ExpressionType.Dynamic;
-		}
-
-		private static Type GetNonNullableType(Type type)
-		{
-			return IsNullableType(type) ? type.GetGenericArguments()[0] : type;
-		}
-
-		private static string GetTypeName(Type type)
-		{
-			var baseType = GetNonNullableType(type);
-			var s = baseType.Name;
-			if (type != baseType) s += '?';
-			return s;
-		}
-
-		static bool IsNumericType(Type type)
-		{
-			return GetNumericTypeKind(type) != 0;
-		}
-
-		private static bool IsSignedIntegralType(Type type)
-		{
-			return GetNumericTypeKind(type) == 2;
-		}
-
-		private static bool IsUnsignedIntegralType(Type type)
-		{
-			return GetNumericTypeKind(type) == 3;
-		}
-
-		private static int GetNumericTypeKind(Type type)
-		{
-			type = GetNonNullableType(type);
-			if (type.IsEnum) return 0;
-			switch (Type.GetTypeCode(type))
-			{
-				case TypeCode.Char:
-				case TypeCode.Single:
-				case TypeCode.Double:
-				case TypeCode.Decimal:
-					return 1;
-				case TypeCode.SByte:
-				case TypeCode.Int16:
-				case TypeCode.Int32:
-				case TypeCode.Int64:
-					return 2;
-				case TypeCode.Byte:
-				case TypeCode.UInt16:
-				case TypeCode.UInt32:
-				case TypeCode.UInt64:
-					return 3;
-				default:
-					return 0;
-			}
-		}
-
-		//static bool IsEnumType(Type type)
-		//{
-		//	return GetNonNullableType(type).IsEnum;
-		//}
-
-		private void CheckAndPromoteOperand(Type signatures, ref Expression expr)
-		{
-			var args = new[] { expr };
-
-			args = PrepareOperandArguments(signatures, args);
-
-			expr = args[0];
-		}
-
-		private void CheckAndPromoteOperands(Type signatures, ref Expression left, ref Expression right)
-		{
-			var args = new[] { left, right };
-
-			args = PrepareOperandArguments(signatures, args);
-
-			left = args[0];
-			right = args[1];
-		}
-
-		private Expression[] PrepareOperandArguments(Type signatures, Expression[] args)
-		{
-			var applicableMethods = FindMethods(signatures, "F", false, args);
-			if (applicableMethods.Length == 1)
-				return applicableMethods[0].PromotedParameters;
-
-			return args;
-		}
-
-		private MemberInfo FindPropertyOrField(Type type, string memberName, bool staticAccess)
-		{
-			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
-					(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
-
-			foreach (var t in SelfAndBaseTypes(type))
-			{
-				var members = t.FindMembers(MemberTypes.Property | MemberTypes.Field, flags, _memberFilterCase, memberName);
-				if (members.Length != 0)
-					return members[0];
-			}
-			return null;
-		}
-
-		private MethodData[] FindMethods(Type type, string methodName, bool staticAccess, Expression[] args)
-		{
-			//var exactMethod = type.GetMethod(methodName, args.Select(p => p.Type).ToArray());
-			//if (exactMethod != null)
-			//{
-			//	return new MethodData[] { new MethodData(){ MethodBase = exactMethod, Parameters = exactMethod.GetParameters(), PromotedParameters = args} };
-			//}
-
-			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
-					(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
-			foreach (var t in SelfAndBaseTypes(type))
-			{
-				var members = t.FindMembers(MemberTypes.Method, flags, _memberFilterCase, methodName);
-				var applicableMethods = FindBestMethod(members.Cast<MethodBase>(), args);
-
-				if (applicableMethods.Length > 0)
-					return applicableMethods;
-			}
-
-			return new MethodData[0];
-		}
-
-		private MethodData[] FindExtensionMethods(string methodName, Expression[] args)
-		{
-			var matchMethods = _arguments.GetExtensionMethods(methodName);
-
-			return FindBestMethod(matchMethods, args);
-		}
-
-		private MethodData[] FindIndexer(Type type, Expression[] args)
-		{
-			foreach (var t in SelfAndBaseTypes(type))
-			{
-				MemberInfo[] members = t.GetDefaultMembers();
-				if (members.Length != 0)
-				{
-					IEnumerable<MethodData> methods = members.
-							OfType<PropertyInfo>().
-							Select(p => (MethodData) new IndexerData(p));
-
-					var applicableMethods = FindBestMethod(methods, args);
-					if (applicableMethods.Length > 0)
-						return applicableMethods;
-				}
-			}
-
-			return new MethodData[0];
-		}
-
-		private static IEnumerable<Type> SelfAndBaseTypes(Type type)
-		{
-			if (type.IsInterface)
-			{
-				var types = new List<Type>();
-				AddInterface(types, type);
-
-				types.Add(typeof(object));
-
-				return types;
-			}
-			return SelfAndBaseClasses(type);
-		}
-
-		private static IEnumerable<Type> SelfAndBaseClasses(Type type)
-		{
-			while (type != null)
-			{
-				yield return type;
-				type = type.BaseType;
-			}
-		}
-
-		private static void AddInterface(List<Type> types, Type type)
-		{
-			if (!types.Contains(type))
-			{
-				types.Add(type);
-				foreach (Type t in type.GetInterfaces())
-				{
-					AddInterface(types, t);
-				}
-			}
-		}
-
-		private static MethodData[] FindBestMethod(IEnumerable<MethodBase> methods, Expression[] args)
-		{
-			return FindBestMethod(methods.Select(MethodData.Gen), args);
-		}
-
-		private static MethodData[] FindBestMethod(IEnumerable<MethodData> methods, Expression[] args)
-		{
-			var applicable = methods.
-					Where(m => CheckIfMethodIsApplicableAndPrepareIt(m, args)).
-					ToArray();
-			if (applicable.Length > 1)
-			{
-				return applicable.
-						Where(m => applicable.All(n => m == n || MethodHasPriority(args, m, n))).
-						ToArray();
-			}
-
-			return applicable;
-		}
-
-		private static bool CheckIfMethodIsApplicableAndPrepareIt(MethodData method, Expression[] args)
-		{
-			if (method.Parameters.Count(y => !y.HasDefaultValue) > args.Length)
-				return false;
-
-			var promotedArgs = new List<Expression>();
-			var declaredWorkingParameters = 0;
-
-			Type paramsArrayTypeFound = null;
-			List<Expression> paramsArrayPromotedArgument = null;
-
-			foreach (var currentArgument in args)
-			{
-				Type parameterType;
-
-				if (paramsArrayTypeFound != null)
-				{
-					parameterType = paramsArrayTypeFound;
-				}
-				else
-				{
-					if (declaredWorkingParameters >= method.Parameters.Length)
-					{
-						return false;
-					}
-
-					var parameterDeclaration = method.Parameters[declaredWorkingParameters];
-					if (parameterDeclaration.IsOut)
-					{
-						return false;
-					}
-
-					parameterType = parameterDeclaration.ParameterType;
-
-					if (HasParamsArrayType(parameterDeclaration))
-					{
-						paramsArrayTypeFound = parameterType;
-					}
-
-					declaredWorkingParameters++;
-				}
-
-				if (paramsArrayPromotedArgument == null)
-				{
-					if (parameterType.IsGenericParameter)
-					{
-						promotedArgs.Add(currentArgument);
-						continue;
-					}
-
-					var promoted = PromoteExpression(currentArgument, parameterType, true);
-					if (promoted != null)
-					{
-						promotedArgs.Add(promoted);
-						continue;
-					}
-				}
-
-				if (paramsArrayTypeFound != null)
-				{
-					var promoted = PromoteExpression(currentArgument, paramsArrayTypeFound.GetElementType(), true);
-					if (promoted != null)
-					{
-						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();
-						paramsArrayPromotedArgument.Add(promoted);
-						continue;
-					}
-				}
-
-				return false;
-			}
-
-			if (paramsArrayPromotedArgument != null)
-			{
-				method.HasParamsArray = true;
-				var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
-				if (paramsArrayElementType == null)
-					throw new Exception("Type is not an array, element not found");
-				promotedArgs.Add(Expression.NewArrayInit(paramsArrayElementType, paramsArrayPromotedArgument));
-			}
-
-			// Add default params, if needed.
-			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select(x => Expression.Constant(x.DefaultValue, x.ParameterType)));
-
-			method.PromotedParameters = promotedArgs.ToArray();
-
-			if (method.MethodBase != null && method.MethodBase.IsGenericMethodDefinition &&
-					method.MethodBase is MethodInfo)
-			{
-				var methodInfo = (MethodInfo)method.MethodBase;
-
-				var actualGenericArgs = ExtractActualGenericArguments(
-					method.Parameters.Select(p => p.ParameterType).ToArray(),
-					method.PromotedParameters.Select(p => p.Type).ToArray());
-
-				var genericArgs = methodInfo.GetGenericArguments()
-					.Select(p => actualGenericArgs[p.Name])
-					.ToArray();
-
-				method.MethodBase = methodInfo.MakeGenericMethod(genericArgs);
-			}
-
-			return true;
-		}
-
-		private static Dictionary<string, Type> ExtractActualGenericArguments(
-			Type[] methodGenericParameters,
-			Type[] methodActualParameters)
-		{
-			var extractedGenericTypes = new Dictionary<string, Type>();
-
-			for (var i = 0; i < methodGenericParameters.Length; i++)
-			{
-				var requestedType = methodGenericParameters[i];
-				var actualType = methodActualParameters[i];
-
-				if (requestedType.IsGenericParameter)
-				{
-					extractedGenericTypes[requestedType.Name] = actualType;
-				}
-				else if (requestedType.ContainsGenericParameters)
-				{
-					var innerGenericTypes = ExtractActualGenericArguments(requestedType.GetGenericArguments(), actualType.GetGenericArguments());
-
-					foreach (var innerGenericType in innerGenericTypes)
-						extractedGenericTypes[innerGenericType.Key] = innerGenericType.Value;
-				}
-			}
-
-			return extractedGenericTypes;
-		}
-
-		private static Expression PromoteExpression(Expression expr, Type type, bool exact)
-		{
-			if (expr.Type == type) return expr;
-			if (expr is ConstantExpression)
-			{
-				var ce = (ConstantExpression)expr;
-				if (ce == ParserConstants.NullLiteralExpression)
-				{
-					if (!type.IsValueType || IsNullableType(type))
-						return Expression.Constant(null, type);
-				}
-			}
-
-			if (type.IsGenericType && !IsNumericType(type))
-			{
-				var genericType = FindAssignableGenericType(expr.Type, type.GetGenericTypeDefinition());
-				if (genericType != null)
-					return Expression.Convert(expr, genericType);
-			}
-
-			if (IsCompatibleWith(expr.Type, type))
-			{
-				if (type.IsValueType || exact)
-				{
-					return Expression.Convert(expr, type);
-				}
-				return expr;
-			}
-
-			return null;
-		}
-
-		private static bool IsCompatibleWith(Type source, Type target)
-		{
-			if (source == target)
-			{
-				return true;
-			}
-
-			if (!target.IsValueType)
-			{
-				return target.IsAssignableFrom(source);
-			}
-			var st = GetNonNullableType(source);
-			var tt = GetNonNullableType(target);
-			if (st != source && tt == target) return false;
-			var sc = st.IsEnum ? TypeCode.Object : Type.GetTypeCode(st);
-			var tc = tt.IsEnum ? TypeCode.Object : Type.GetTypeCode(tt);
-			switch (sc)
-			{
-				case TypeCode.SByte:
-					switch (tc)
-					{
-						case TypeCode.SByte:
-						case TypeCode.Int16:
-						case TypeCode.Int32:
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Byte:
-					switch (tc)
-					{
-						case TypeCode.Byte:
-						case TypeCode.Int16:
-						case TypeCode.UInt16:
-						case TypeCode.Int32:
-						case TypeCode.UInt32:
-						case TypeCode.Int64:
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Int16:
-					switch (tc)
-					{
-						case TypeCode.Int16:
-						case TypeCode.Int32:
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.UInt16:
-					switch (tc)
-					{
-						case TypeCode.UInt16:
-						case TypeCode.Int32:
-						case TypeCode.UInt32:
-						case TypeCode.Int64:
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Int32:
-					switch (tc)
-					{
-						case TypeCode.Int32:
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.UInt32:
-					switch (tc)
-					{
-						case TypeCode.UInt32:
-						case TypeCode.Int64:
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Int64:
-					switch (tc)
-					{
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.UInt64:
-					switch (tc)
-					{
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Single:
-					switch (tc)
-					{
-						case TypeCode.Single:
-						case TypeCode.Double:
-							return true;
-					}
-					break;
-				default:
-					if (st == tt) return true;
-					break;
-			}
-			return false;
-		}
-
-		private static bool IsWritable(Expression expression)
-		{
-			switch (expression.NodeType)
-			{
-				case ExpressionType.Index:
-					PropertyInfo indexer = ((IndexExpression)expression).Indexer;
-					return indexer == null || indexer.CanWrite;
-				case ExpressionType.MemberAccess:
-					MemberInfo member = ((MemberExpression)expression).Member;
-					var prop = member as PropertyInfo;
-					if (prop != null)
-						return prop.CanWrite;
-					else
-					{
-						var field = (FieldInfo)member;
-						return !(field.IsInitOnly || field.IsLiteral);
-					}
-				case ExpressionType.Parameter:
-					return true;
-			}
-
-			return false;
-		}
-
-		// from http://stackoverflow.com/a/1075059/209727
-		private static Type FindAssignableGenericType(Type givenType, Type genericTypeDefinition)
-		{
-			var interfaceTypes = givenType.GetInterfaces();
-
-			foreach (var it in interfaceTypes)
-			{
-				if (it.IsGenericType && it.GetGenericTypeDefinition() == genericTypeDefinition)
-				{
-					return it;
-				}
-			}
-
-			if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericTypeDefinition)
-				return givenType;
-
-			var baseType = givenType.BaseType;
-			if (baseType == null)
-				return null;
-
-			return FindAssignableGenericType(baseType, genericTypeDefinition);
-		}
-
-		private static bool HasParamsArrayType(ParameterInfo parameterInfo)
-		{
-			return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
-		}
-
-		private static Type GetParameterType(ParameterInfo parameterInfo)
-		{
-			var isParamsArray = HasParamsArrayType(parameterInfo);
-			var type = isParamsArray
-				? parameterInfo.ParameterType.GetElementType()
-				: parameterInfo.ParameterType;
-			return type;
-		}
-
-		private static bool MethodHasPriority(Expression[] args, MethodData method, MethodData otherMethod)
-		{
-			if (method.HasParamsArray == false && otherMethod.HasParamsArray)
-				return true;
-			if (method.HasParamsArray && otherMethod.HasParamsArray == false)
-				return false;
-
-			//if (m1.Parameters.Length > m2.Parameters.Length)
-			//	return true;
-			//else if (m1.Parameters.Length < m2.Parameters.Length)
-			//	return false;
-
-			var better = false;
-			for (var i = 0; i < args.Length; i++)
-			{
-				var methodParam = method.Parameters[i];
-				var otherMethodParam = otherMethod.Parameters[i];
-				var methodParamType = GetParameterType(methodParam);
-				var otherMethodParamType = GetParameterType(otherMethodParam);
-				var c = CompareConversions(args[i].Type, methodParamType, otherMethodParamType);
-				if (c < 0)
-					return false;
-				if (c > 0)
-					better = true;
-				if (HasParamsArrayType(methodParam) || HasParamsArrayType(otherMethodParam))
-					break;
-			}
-			return better;
-		}
-
-		// Return 1 if s -> t1 is a better conversion than s -> t2
-		// Return -1 if s -> t2 is a better conversion than s -> t1
-		// Return 0 if neither conversion is better
-		private static int CompareConversions(Type s, Type t1, Type t2)
-		{
-			if (t1 == t2) return 0;
-			if (s == t1) return 1;
-			if (s == t2) return -1;
-
-			var assignableT1 = t1.IsAssignableFrom(s);
-			var assignableT2 = t2.IsAssignableFrom(s);
-			if (assignableT1 && !assignableT2) return 1;
-			if (assignableT2 && !assignableT1) return -1;
-
-			var compatibleT1T2 = IsCompatibleWith(t1, t2);
-			var compatibleT2T1 = IsCompatibleWith(t2, t1);
-			if (compatibleT1T2 && !compatibleT2T1) return 1;
-			if (compatibleT2T1 && !compatibleT1T2) return -1;
-
-			if (IsSignedIntegralType(t1) && IsUnsignedIntegralType(t2)) return 1;
-			if (IsSignedIntegralType(t2) && IsUnsignedIntegralType(t1)) return -1;
-
-			return 0;
-		}
-
-		private static Expression GenerateEqual(Expression left, Expression right)
-		{
-			return Expression.Equal(left, right);
-		}
-
-		private static Expression GenerateNotEqual(Expression left, Expression right)
-		{
-			return Expression.NotEqual(left, right);
-		}
-
-		private static Expression GenerateGreaterThan(Expression left, Expression right)
-		{
-			if (left.Type == typeof(string))
-			{
-				return Expression.GreaterThan(
-						GenerateStaticMethodCall("Compare", left, right),
-						Expression.Constant(0)
-				);
-			}
-			return Expression.GreaterThan(left, right);
-		}
-
-		private static Expression GenerateGreaterThanEqual(Expression left, Expression right)
-		{
-			if (left.Type == typeof(string))
-			{
-				return Expression.GreaterThanOrEqual(
-						GenerateStaticMethodCall("Compare", left, right),
-						Expression.Constant(0)
-				);
-			}
-			return Expression.GreaterThanOrEqual(left, right);
-		}
-
-		private static Expression GenerateLessThan(Expression left, Expression right)
-		{
-			if (left.Type == typeof(string))
-			{
-				return Expression.LessThan(
-						GenerateStaticMethodCall("Compare", left, right),
-						Expression.Constant(0)
-				);
-			}
-			return Expression.LessThan(left, right);
-		}
-
-		private static Expression GenerateLessThanEqual(Expression left, Expression right)
-		{
-			if (left.Type == typeof(string))
-			{
-				return Expression.LessThanOrEqual(
-						GenerateStaticMethodCall("Compare", left, right),
-						Expression.Constant(0)
-				);
-			}
-			return Expression.LessThanOrEqual(left, right);
-		}
-
-		private static Expression GenerateAdd(Expression left, Expression right)
-		{
-			return Expression.Add(left, right);
-		}
-
-		private static Expression GenerateSubtract(Expression left, Expression right)
-		{
-			return Expression.Subtract(left, right);
-		}
-
-		private static Expression GenerateStringConcat(Expression left, Expression right)
-		{
-			var concatMethod = typeof(string).GetMethod("Concat", new[] { typeof(object), typeof(object) });
-			if (concatMethod == null)
-				throw new Exception("String concat method not found");
-
-			var rightObj =
-				right.Type.IsValueType
-				? Expression.ConvertChecked(right, typeof(object))
-				: right;
-			var leftObj =
-				left.Type.IsValueType
-				? Expression.ConvertChecked(left, typeof(object))
-				: left;
-
-			return Expression.Call(
-					null,
-					concatMethod,
-					new[] { leftObj, rightObj });
-		}
-
-		private static MethodInfo GetStaticMethod(string methodName, Expression left, Expression right)
-		{
-			return left.Type.GetMethod(methodName, new[] { left.Type, right.Type });
-		}
-
-		private static Expression GenerateStaticMethodCall(string methodName, Expression left, Expression right)
-		{
-			return Expression.Call(null, GetStaticMethod(methodName, left, right), new[] { left, right });
-		}
+		// ******************************************
+		// ******************************************
+		// ******************************************
 
 		private void SetTextPos(int pos)
 		{
@@ -2056,7 +1176,7 @@ namespace DynamicExpresso.Parsing
 					}
 
 					if (_parsePosition == _expressionTextLength)
-						throw CreateParseException(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
+						throw ParseException.Create(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
 
 					NextChar();
 
@@ -2074,7 +1194,7 @@ namespace DynamicExpresso.Parsing
 					}
 
 					if (_parsePosition == _expressionTextLength)
-						throw CreateParseException(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
+						throw ParseException.Create(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
 
 					NextChar();
 
@@ -2148,7 +1268,7 @@ namespace DynamicExpresso.Parsing
 						t = TokenId.End;
 						break;
 					}
-					throw CreateParseException(_parsePosition, ErrorMessages.InvalidCharacter, _parseChar);
+					throw ParseException.Create(_parsePosition, ErrorMessages.InvalidCharacter, _parseChar);
 			}
 			_token.id = t;
 			_token.text = _expressionText.Substring(tokenPos, _parsePosition - tokenPos);
@@ -2167,71 +1287,21 @@ namespace DynamicExpresso.Parsing
 		private void ValidateDigit()
 		{
 			if (!char.IsDigit(_parseChar))
-				throw CreateParseException(_parsePosition, ErrorMessages.DigitExpected);
+				throw ParseException.Create(_parsePosition, ErrorMessages.DigitExpected);
 		}
 
 		// ReSharper disable once UnusedParameter.Local
 		private void ValidateToken(TokenId t, string errorMessage)
 		{
 			if (_token.id != t)
-				throw CreateParseException(_token.pos, errorMessage);
+				throw ParseException.Create(_token.pos, errorMessage);
 		}
 
 		// ReSharper disable once UnusedParameter.Local
 		private void ValidateToken(TokenId t)
 		{
 			if (_token.id != t)
-				throw CreateParseException(_token.pos, ErrorMessages.SyntaxError);
-		}
-
-		private static Exception CreateParseException(int pos, string format, params object[] args)
-		{
-			return new ParseException(string.Format(format, args), pos);
-		}
-
-		private class MethodData
-		{
-			public MethodBase MethodBase;
-			public ParameterInfo[] Parameters;
-			public Expression[] PromotedParameters;
-			public bool HasParamsArray;
-
-			public static MethodData Gen(MethodBase method)
-			{
-				return new MethodData
-				{
-					MethodBase = method,
-					Parameters = method.GetParameters()
-				};
-			}
-		}
-
-		private class IndexerData : MethodData
-		{
-			public readonly PropertyInfo Indexer;
-
-			public IndexerData(PropertyInfo indexer)
-			{
-				Indexer = indexer;
-
-				var method = indexer.GetGetMethod();
-				if (method != null)
-				{
-					Parameters = method.GetParameters();
-				}
-				else
-				{
-					method = indexer.GetSetMethod();
-					Parameters = RemoveLast(method.GetParameters());
-				}
-			}
-
-			private static T[] RemoveLast<T>(T[] array)
-			{
-				T[] result = new T[array.Length - 1];
-				Array.Copy(array, 0, result, 0, result.Length);
-				return result;
-			}
+				throw ParseException.Create(_token.pos, ErrorMessages.SyntaxError);
 		}
 	}
 }

--- a/src/DynamicExpresso.Core/Parsing/Types.cs
+++ b/src/DynamicExpresso.Core/Parsing/Types.cs
@@ -1,0 +1,287 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace DynamicExpresso.Parsing
+{
+	internal static class Types
+	{
+		public static bool IsNullableType(Type type)
+		{
+			return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+		}
+
+		public static bool IsDynamicType(Type type)
+		{
+			return typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type);
+		}
+
+		private static Type GetNonNullableType(Type type)
+		{
+			return IsNullableType(type) ? type.GetGenericArguments()[0] : type;
+		}
+
+		public static string GetTypeName(Type type)
+		{
+			var baseType = GetNonNullableType(type);
+			var s = baseType.Name;
+			if (type != baseType) s += '?';
+			return s;
+		}
+
+		public static bool IsNumericType(Type type)
+		{
+			return GetNumericTypeKind(type) != 0;
+		}
+
+		private static bool IsSignedIntegralType(Type type)
+		{
+			return GetNumericTypeKind(type) == 2;
+		}
+
+		private static bool IsUnsignedIntegralType(Type type)
+		{
+			return GetNumericTypeKind(type) == 3;
+		}
+
+		private static int GetNumericTypeKind(Type type)
+		{
+			type = GetNonNullableType(type);
+			if (type.IsEnum) return 0;
+			switch (Type.GetTypeCode(type))
+			{
+				case TypeCode.Char:
+				case TypeCode.Single:
+				case TypeCode.Double:
+				case TypeCode.Decimal:
+					return 1;
+				case TypeCode.SByte:
+				case TypeCode.Int16:
+				case TypeCode.Int32:
+				case TypeCode.Int64:
+					return 2;
+				case TypeCode.Byte:
+				case TypeCode.UInt16:
+				case TypeCode.UInt32:
+				case TypeCode.UInt64:
+					return 3;
+				default:
+					return 0;
+			}
+		}
+
+		//static bool IsEnumType(Type type)
+		//{
+		//	return GetNonNullableType(type).IsEnum;
+		//}
+
+		public static bool IsCompatibleWith(Type source, Type target)
+		{
+			if (source == target)
+			{
+				return true;
+			}
+
+			if (!target.IsValueType)
+			{
+				return target.IsAssignableFrom(source);
+			}
+			var st = GetNonNullableType(source);
+			var tt = GetNonNullableType(target);
+			if (st != source && tt == target) return false;
+			var sc = st.IsEnum ? TypeCode.Object : Type.GetTypeCode(st);
+			var tc = tt.IsEnum ? TypeCode.Object : Type.GetTypeCode(tt);
+			switch (sc)
+			{
+				case TypeCode.SByte:
+					switch (tc)
+					{
+						case TypeCode.SByte:
+						case TypeCode.Int16:
+						case TypeCode.Int32:
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Byte:
+					switch (tc)
+					{
+						case TypeCode.Byte:
+						case TypeCode.Int16:
+						case TypeCode.UInt16:
+						case TypeCode.Int32:
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Int16:
+					switch (tc)
+					{
+						case TypeCode.Int16:
+						case TypeCode.Int32:
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.UInt16:
+					switch (tc)
+					{
+						case TypeCode.UInt16:
+						case TypeCode.Int32:
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Int32:
+					switch (tc)
+					{
+						case TypeCode.Int32:
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.UInt32:
+					switch (tc)
+					{
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Int64:
+					switch (tc)
+					{
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.UInt64:
+					switch (tc)
+					{
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Single:
+					switch (tc)
+					{
+						case TypeCode.Single:
+						case TypeCode.Double:
+							return true;
+					}
+					break;
+				default:
+					if (st == tt) return true;
+					break;
+			}
+			return false;
+		}
+
+		// Return 1 if s -> t1 is a better conversion than s -> t2
+		// Return -1 if s -> t2 is a better conversion than s -> t1
+		// Return 0 if neither conversion is better
+		public static int CompareConversions(Type s, Type t1, Type t2)
+		{
+			if (t1 == t2) return 0;
+			if (s == t1) return 1;
+			if (s == t2) return -1;
+
+			var assignableT1 = t1.IsAssignableFrom(s);
+			var assignableT2 = t2.IsAssignableFrom(s);
+			if (assignableT1 && !assignableT2) return 1;
+			if (assignableT2 && !assignableT1) return -1;
+
+			var compatibleT1T2 = IsCompatibleWith(t1, t2);
+			var compatibleT2T1 = IsCompatibleWith(t2, t1);
+			if (compatibleT1T2 && !compatibleT2T1) return 1;
+			if (compatibleT2T1 && !compatibleT1T2) return -1;
+
+			if (IsSignedIntegralType(t1) && IsUnsignedIntegralType(t2)) return 1;
+			if (IsSignedIntegralType(t2) && IsUnsignedIntegralType(t1)) return -1;
+
+			return 0;
+		}
+
+		//static Type FindGenericType(Type generic, Type type)
+		//{
+		//	while (type != null && type != typeof(object))
+		//	{
+		//		if (type.IsGenericType && type.GetGenericTypeDefinition() == generic) return type;
+		//		if (generic.IsInterface)
+		//		{
+		//			foreach (Type intfType in type.GetInterfaces())
+		//			{
+		//				Type found = FindGenericType(generic, intfType);
+		//				if (found != null) return found;
+		//			}
+		//		}
+		//		type = type.BaseType;
+		//	}
+		//	return null;
+		//}
+		
+		public static IEnumerable<Type> SelfAndBaseTypes(Type type)
+		{
+			if (type.IsInterface)
+			{
+				var types = new List<Type>();
+				AddInterface(types, type);
+
+				types.Add(typeof(object));
+
+				return types;
+			}
+			return SelfAndBaseClasses(type);
+		}
+
+		private static IEnumerable<Type> SelfAndBaseClasses(Type type)
+		{
+			while (type != null)
+			{
+				yield return type;
+				type = type.BaseType;
+			}
+		}
+
+		private static void AddInterface(List<Type> types, Type type)
+		{
+			if (!types.Contains(type))
+			{
+				types.Add(type);
+				foreach (Type t in type.GetInterfaces())
+				{
+					AddInterface(types, t);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
`Parser.cs` contains 2237 lines, so I tried to split it into three files/classes:

- `Parser.cs` (1307 lines) - methods that use and change the state of the parser
- `Expressions.cs` (663 lines) - methods that create, change and use expressions
- `Types.cs` (287 lines) - methods that get information about types

What do you think about this?