### PR TITLE
added support for null enum

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/ParseSignatures.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParseSignatures.cs
@@ -79,6 +79,11 @@ namespace DynamicExpresso.Parsing
 			void F(bool? x);
 		}
 
+        public interface ICustomSignature 
+        {
+            void F<T1, T2>(T1 x, T2 y);
+        }
+
 		//interface IEnumerableSignatures
 		//{
 		//    void Where(bool predicate);

--- a/test/DynamicExpresso.UnitTest/NullableTest.cs
+++ b/test/DynamicExpresso.UnitTest/NullableTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using static DynamicExpresso.UnitTest.TypesTest;
 // ReSharper disable ConvertNullableToShortForm
 // ReSharper disable PossibleNullReferenceException
 
@@ -227,5 +228,57 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(expected, lambda.Invoke());
 			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
 		}
-	}
+
+        [Test]
+        public void Nullable_Enum_with_left_null()
+        {
+            MyCustomEnum? a = MyCustomEnum.Value1;
+            MyCustomEnum b = MyCustomEnum.Value1;
+
+            var interpreter = new Interpreter();
+            interpreter.SetVariable("a", a, typeof(MyCustomEnum));
+            interpreter.SetVariable("b", b, typeof(Nullable<MyCustomEnum>));
+            var expectedReturnType = typeof(bool);
+
+            var expected = a == b;
+            var lambda = interpreter.Parse("a == b");
+            Assert.AreEqual(expected, lambda.Invoke());
+            Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+        }
+
+        [Test]
+        public void Nullable_Enum_with_right_null()
+        {
+            MyCustomEnum a = MyCustomEnum.Value1;
+            MyCustomEnum? b = MyCustomEnum.Value1;
+
+            var interpreter = new Interpreter();
+            interpreter.SetVariable("a", a, typeof(Nullable<MyCustomEnum>));
+            interpreter.SetVariable("b", b, typeof(MyCustomEnum));
+            var expectedReturnType = typeof(bool);
+
+            var expected = a == b;
+            var lambda = interpreter.Parse("a == b");
+            Assert.AreEqual(expected, lambda.Invoke());
+            Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+        }
+
+
+        [Test]
+        public void Nullable_Enum_Nullable_Enum()
+        {
+            MyCustomEnum? a = MyCustomEnum.Value1;
+            MyCustomEnum? b = MyCustomEnum.Value1;
+
+            var interpreter = new Interpreter();
+            interpreter.SetVariable("a", a, typeof(Nullable<MyCustomEnum>));
+            interpreter.SetVariable("b", b, typeof(Nullable<MyCustomEnum>));
+            var expectedReturnType = typeof(bool);
+
+            var expected = a == b;
+            var lambda = interpreter.Parse("a == b");
+            Assert.AreEqual(expected, lambda.Invoke());
+            Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+        }
+    }
 }


### PR DESCRIPTION
When parsing an expression containing a type of null enum, an error occurs. I tried to fix it.
