### PR TITLE
Allow assignment using implicit operator cast

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -102,9 +102,19 @@ namespace DynamicExpresso.Parsing
 
 				var right = ParseAssignment();
 				var promoted = PromoteExpression(right, left.Type, true);
-				if (promoted == null)
-					throw CreateParseException(_token.pos, ErrorMessages.CannotConvertValue,
-						GetTypeName(right.Type), GetTypeName(left.Type));
+				if (promoted == null) 
+				{
+					try
+					{
+						promoted = Expression.ConvertChecked(right, left.Type);
+					}
+					catch (InvalidOperationException)
+					{
+						throw CreateParseException(_token.pos, ErrorMessages.CannotConvertValue,
+							GetTypeName(right.Type), GetTypeName(left.Type));
+					}
+
+				}
 
 				left = Expression.Assign(left, promoted);
 			}

--- a/test/DynamicExpresso.UnitTest/AssignmentTest.cs
+++ b/test/DynamicExpresso.UnitTest/AssignmentTest.cs
@@ -20,7 +20,7 @@ namespace DynamicExpresso.UnitTest {
    [TestFixture]
    public class AssignmentTest {
       [Test]
-      public void ImplicitOperatorAssignment()
+      public void Can_Assign_Using_ImplicitCast()
       {
          var container = new Container();
 

--- a/test/DynamicExpresso.UnitTest/AssignmentTest.cs
+++ b/test/DynamicExpresso.UnitTest/AssignmentTest.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace DynamicExpresso.UnitTest {
+   public class BoxedValue {
+      private BoxedValue(object value)
+      {
+         Value = value;
+      }
+
+      public object Value { get; }
+      public static implicit operator BoxedValue(string other) => new BoxedValue(other);
+      public static implicit operator BoxedValue(int other) => new BoxedValue(other);
+   }
+
+   public class Container {
+      // ReSharper disable once UnusedAutoPropertyAccessor.Global
+      public BoxedValue BoxedValue { get; set; }
+   }
+
+   [TestFixture]
+   public class AssignmentTest {
+      [Test]
+      public void ImplicitOperatorAssignment()
+      {
+         var container = new Container();
+
+         var interpreter = new Interpreter();
+         interpreter.SetVariable("Container", container);
+         
+         interpreter.Eval("Container.BoxedValue = \"Test\"");
+         Assert.AreEqual("Test", container.BoxedValue.Value);
+         
+         interpreter.Eval("Container.BoxedValue = 2");
+         Assert.AreEqual(2, container.BoxedValue.Value);
+      }
+   }
+}


### PR DESCRIPTION
In ParseAssignment, instead of throwing immediately when PromoteExpression returns null, calls ConvertChecked -- which I got from https://github.com/davideicardi/DynamicExpresso/issues/7

This enables support for implicit operator casts in assignments. I wouldn't expect this to break anything, given it would otherwise throw.

Use case: using this library in a partial trust environment (MS Dynamics 365) where reflection support is limited and the dynamic type is not allowed. As an alternative, I'm using a boxed value type with ImplicitOperator to handle specific type conversions/comparisons/assignments I want to support (to store business logic configuration). In .NET standard mode, everything works nicely.

Thanks for the great library!