### PR TITLE
Fix problems in the comparison of types and their nullable counterparts. 

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -2198,19 +2198,14 @@ namespace DynamicExpresso.Parsing
 
 		private static Expression GenerateNullableTypeConversion(Expression expr)
 		{
-			if(expr.Type.IsGenericType && expr.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+			var exprType = expr.Type;
+
+			if (exprType.IsGenericType && exprType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
 				return expr;
             }
 
 			var conversionType = typeof(Nullable<>).MakeGenericType(expr.Type);
-
-			var exprType = expr.Type;
-			if (exprType == conversionType)
-			{
-				return expr;
-			}
-
 			return Expression.ConvertChecked(expr, conversionType);
 		}
 

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -262,6 +262,12 @@ namespace DynamicExpresso.Parsing
 				//			op.text, ref left, ref right, op.pos);
 				//}
 
+				if((IsNullableType(left.Type) || IsNullableType(right.Type)) && (GetNonNullableType(left.Type) == right.Type || GetNonNullableType(right.Type) == left.Type))
+                {
+					left = GenerateNullableTypeConversion(left);
+					right = GenerateNullableTypeConversion(right);
+				}
+
 				CheckAndPromoteOperands(
 					isEquality ? typeof(ParseSignatures.IEqualitySignatures) : typeof(ParseSignatures.IRelationalSignatures),
 					ref left,
@@ -1800,6 +1806,7 @@ namespace DynamicExpresso.Parsing
 						Expression.Constant(0)
 				);
 			}
+
 			return Expression.LessThan(left, right);
 		}
 
@@ -2188,6 +2195,25 @@ namespace DynamicExpresso.Parsing
 		{
 			return new ParseException(string.Format(format, args), pos);
 		}
+
+		private static Expression GenerateNullableTypeConversion(Expression expr)
+		{
+			if(expr.Type.IsGenericType && expr.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+				return expr;
+            }
+
+			var conversionType = typeof(Nullable<>).MakeGenericType(expr.Type);
+
+			var exprType = expr.Type;
+			if (exprType == conversionType)
+			{
+				return expr;
+			}
+
+			return Expression.ConvertChecked(expr, conversionType);
+		}
+
 
 		private class MethodData
 		{

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -263,7 +263,7 @@ namespace DynamicExpresso.Parsing
 				//}
 
 				if((IsNullableType(left.Type) || IsNullableType(right.Type)) && (GetNonNullableType(left.Type) == right.Type || GetNonNullableType(right.Type) == left.Type))
-                {
+				{
 					left = GenerateNullableTypeConversion(left);
 					right = GenerateNullableTypeConversion(right);
 				}
@@ -2201,9 +2201,9 @@ namespace DynamicExpresso.Parsing
 			var exprType = expr.Type;
 
 			if (exprType.IsGenericType && exprType.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
+			{
 				return expr;
-            }
+			}
 
 			var conversionType = typeof(Nullable<>).MakeGenericType(expr.Type);
 			return Expression.ConvertChecked(expr, conversionType);

--- a/test/DynamicExpresso.UnitTest/NullableTest.cs
+++ b/test/DynamicExpresso.UnitTest/NullableTest.cs
@@ -230,7 +230,7 @@ namespace DynamicExpresso.UnitTest
 
 		[Test]
 		public void NullableDateTimeOffset_DatetimeOffset()
-        {
+		{
 			var a = DateTimeOffset.Now;
 			DateTimeOffset? b = DateTimeOffset.Now.AddDays(1);
 			var c = b.Value;

--- a/test/DynamicExpresso.UnitTest/NullableTest.cs
+++ b/test/DynamicExpresso.UnitTest/NullableTest.cs
@@ -227,5 +227,49 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(expected, lambda.Invoke());
 			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
 		}
+
+		[Test]
+		public void NullableDateTimeOffset_DatetimeOffset()
+        {
+			var a = DateTimeOffset.Now;
+			DateTimeOffset? b = DateTimeOffset.Now.AddDays(1);
+			var c = b.Value;
+
+			var interpreter = new Interpreter();
+			interpreter.SetVariable("a", a, typeof(DateTimeOffset));
+			interpreter.SetVariable("b", b, typeof(Nullable<DateTimeOffset>));
+			interpreter.SetVariable("c", c, typeof(Nullable<DateTimeOffset>));
+			var expectedReturnType = typeof(bool);
+
+			var expected = a < b;
+			var lambda = interpreter.Parse("a < b");
+			Assert.AreEqual(expected, lambda.Invoke());
+			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+
+			expected = a > b;
+			lambda = interpreter.Parse("a > b");
+			Assert.AreEqual(expected, lambda.Invoke());
+			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+
+			expected = a == b;
+			lambda = interpreter.Parse("a == b");
+			Assert.AreEqual(expected, lambda.Invoke());
+			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+
+			expected = a != b;
+			lambda = interpreter.Parse("a != b");
+			Assert.AreEqual(expected, lambda.Invoke());
+			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+
+			expected = b == c;
+			lambda = interpreter.Parse("b == b");
+			Assert.AreEqual(expected, lambda.Invoke());
+			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+
+			expected = b != c;
+			lambda = interpreter.Parse("b != c");
+			Assert.AreEqual(expected, lambda.Invoke());
+			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/NullableTest.cs
+++ b/test/DynamicExpresso.UnitTest/NullableTest.cs
@@ -238,7 +238,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			interpreter.SetVariable("a", a, typeof(DateTimeOffset));
 			interpreter.SetVariable("b", b, typeof(Nullable<DateTimeOffset>));
-			interpreter.SetVariable("c", c, typeof(Nullable<DateTimeOffset>));
+			interpreter.SetVariable("c", c, typeof(DateTimeOffset));
 			var expectedReturnType = typeof(bool);
 
 			var expected = a < b;


### PR DESCRIPTION
# What was the issue?

The C# compiler automatically allows for a comparison of types and their nullables, because even though the specific operators (\<, \>, ==, !=, ...) might not be explicitly defined between T and Nullable\<T\>, they are automatically generated.

However, this does not happen for expressions. 

# What has been done?
This PR emulates what is automatically generated by explicitly converting the T to Nullable\<T\> to then allow for a comparisons between Nullable\<T\> and Nullable\<T\>. 

Closes #123 