### PR TITLE
Allow dynamic types for .NET Standard build #111

### DIFF
--- a/src/DynamicExpresso.Core/DynamicExpresso.Core.csproj
+++ b/src/DynamicExpresso.Core/DynamicExpresso.Core.csproj
@@ -25,4 +25,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2')) ">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1037,9 +1037,6 @@ namespace DynamicExpresso.Parsing
 
 		private static Expression ParseDynamicProperty(Type type, Expression instance, string propertyOrFieldName)
 		{
-#if NETSTANDARD2_0
-			throw new NotImplementedException("Dynamic types are not supported in .NET Standard build");
-#else
 			var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
 				Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
 				propertyOrFieldName,
@@ -1048,14 +1045,10 @@ namespace DynamicExpresso.Parsing
 				);
 
 			return Expression.Dynamic(binder, typeof(object), instance);
-#endif
 		}
 
 		private static Expression ParseDynamicMethodInvocation(Type type, Expression instance, string methodName, Expression[] args)
 		{
-#if NETSTANDARD2_0
-			throw new NotImplementedException("Dynamic types are not supported in .NET Standard build");
-#else
 			var argsDynamic = args.ToList();
 			argsDynamic.Insert(0, instance);
 			var binderM = Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
@@ -1067,7 +1060,6 @@ namespace DynamicExpresso.Parsing
 				);
 
 			return Expression.Dynamic(binderM, typeof(object), argsDynamic);
-#endif
 		}
 
 		private Expression[] ParseArgumentList()

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -6,9 +6,6 @@ using System.Linq.Expressions;
 
 namespace DynamicExpresso.UnitTest
 {
-#if NETCOREAPP2_0
-	[Ignore("Not supported on dotnet core")]
-#endif
 	[TestFixture]
 	public class DynamicTest
 	{


### PR DESCRIPTION
Add Microsoft.CSharp package to allow for dynamic types in .Net Standard 2.0