### PR TITLE
Unary and binary operators: find the proper overload by also checking the base classes

### DIFF
--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -77,7 +77,29 @@ namespace DynamicExpresso.Resources {
                 return ResourceManager.GetString("AmbiguousMethodInvocation", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Ambiguous invocation of user defined operator &apos;{0}&apos; in type &apos;{1}&apos;.
+        /// </summary>
+        internal static string AmbiguousUnaryOperatorInvocation
+        {
+            get
+            {
+                return ResourceManager.GetString("AmbiguousUnaryOperatorInvocation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Ambiguous invocation of user defined operator &apos;{0}&apos; in types &apos;{1}&apos; and &apos;{2}&apos;.
+        /// </summary>
+        internal static string AmbiguousBinaryOperatorInvocation
+        {
+            get
+            {
+                return ResourceManager.GetString("AmbiguousBinaryOperatorInvocation", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Argument list incompatible with delegate expression.
         /// </summary>

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -234,4 +234,10 @@
   <data name="InvalidOperation" xml:space="preserve">
     <value>Invalid Operation</value>
   </data>
+  <data name="AmbiguousBinaryOperatorInvocation" xml:space="preserve">
+    <value>Ambiguous invocation of user defined operator '{0}' in types '{1}' and '{2}'</value>
+  </data>
+  <data name="AmbiguousUnaryOperatorInvocation" xml:space="preserve">
+    <value>Ambiguous invocation of user defined operator '{0}' in type '{1}'</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/OperatorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/OperatorsTest.cs
@@ -581,6 +581,55 @@ namespace DynamicExpresso.UnitTest
 			}
 		}
 
+		private class DerivedClassWithOverloadedBinaryOperators : ClassWithOverloadedBinaryOperators
+		{
+			public DerivedClassWithOverloadedBinaryOperators(int value) : base(value)
+			{
+			}
+		}
+
+		[Test]
+		public void Can_use_overloaded_operators_on_derived_class()
+		{
+			var target = new Interpreter();
+
+			var x = new DerivedClassWithOverloadedBinaryOperators(3);
+			target.SetVariable("x", x);
+
+			string y = "5";
+			Assert.IsFalse(x == y);
+			Assert.IsFalse(target.Eval<bool>("x == y", new Parameter("y", y)));
+
+			y = "3";
+			Assert.IsTrue(x == y);
+			Assert.IsTrue(target.Eval<bool>("x == y", new Parameter("y", y)));
+
+			Assert.IsFalse(target.Eval<bool>("x == \"4\""));
+			Assert.IsTrue(target.Eval<bool>("x == \"3\""));
+
+			Assert.IsTrue(!x == "-3");
+			Assert.IsTrue(target.Eval<bool>("!x == \"-3\""));
+
+			var z = new DerivedClassWithOverloadedBinaryOperators(10);
+			Assert.IsTrue((x + z) == "13");
+			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+		}
+
+		[Test]
+		public void Can_mix_overloaded_operators()
+		{
+			var target = new Interpreter();
+
+			var x = new ClassWithOverloadedBinaryOperators(3);
+			target.SetVariable("x", x);
+
+			// ensure we don't trigger an ambiguous operator exception
+			var z = new DerivedClassWithOverloadedBinaryOperators(10);
+			Assert.IsTrue((x + z) == "13");
+			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+		}
+
+
 		[Test]
 		public void Throw_an_exception_if_a_custom_type_doesnt_define_equal_operator()
 		{


### PR DESCRIPTION
This is an attempt at fixing #135 . The gist is to try to find the proper user defined operator instead of solely relying on the Linq resolution (which doesn't check the base classes).

There were already some tests for user defined operators, I've added a use case to expand on it.