### PR TITLE
Fix user defined operator resolution

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1937,6 +1937,10 @@ namespace DynamicExpresso.Parsing
 				// we found a matching user defined operator on either type, but it might be the same method
 				if (userDefinedOperator != null && rightOperator != null && !ReferenceEquals(userDefinedOperator.MethodBase, rightOperator.MethodBase))
 					throw error;
+
+				// we didn't find an operator on the left type, but we found one on the right type
+				if (userDefinedOperator == null && rightOperator != null)
+					userDefinedOperator = rightOperator;
 			}
 
 			return userDefinedOperator;

--- a/test/DynamicExpresso.UnitTest/OperatorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/OperatorsTest.cs
@@ -567,6 +567,16 @@ namespace DynamicExpresso.UnitTest
 				return new ClassWithOverloadedBinaryOperators(-instance._value);
 			}
 
+			public static ClassWithOverloadedBinaryOperators operator *(ClassWithOverloadedBinaryOperators left, int right)
+			{
+				return new ClassWithOverloadedBinaryOperators(left._value * right);
+			}
+
+			public static ClassWithOverloadedBinaryOperators operator *(int left, ClassWithOverloadedBinaryOperators right)
+			{
+				return new ClassWithOverloadedBinaryOperators(left * right._value);
+			}
+
 			public override bool Equals(object obj)
 			{
 				if (obj == null)
@@ -613,6 +623,13 @@ namespace DynamicExpresso.UnitTest
 			var z = new DerivedClassWithOverloadedBinaryOperators(10);
 			Assert.IsTrue((x + z) == "13");
 			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+
+			Assert.IsTrue((x * 4) == "12");
+			Assert.IsTrue(target.Eval<bool>("(x * 4) == \"12\""));
+
+			// ensure a user defined operator can be found if it's on the right side operand's type
+			Assert.IsTrue((4 * x) == "12");
+			Assert.IsTrue(target.Eval<bool>("(4 * x) == \"12\""));
 		}
 
 		[Test]


### PR DESCRIPTION
This is a follow up of my previous PR #135 . If a user defined operator was only defined on the right operand's type, it was not taken into account..