### PR TITLE
Allow the registration of function overloads

### DIFF
--- a/src/DynamicExpresso.Core/Identifier.cs
+++ b/src/DynamicExpresso.Core/Identifier.cs
@@ -39,9 +39,15 @@ namespace DynamicExpresso
 	/// </summary>
 	internal class MethodGroupExpression : Expression
 	{
-		private readonly List<Expression> _overloads = new List<Expression>();
+		private readonly List<Delegate> _overloads = new List<Delegate>();
 
-		internal IReadOnlyCollection<Expression> Overloads => _overloads.AsReadOnly();
+		internal IReadOnlyCollection<Delegate> Overloads
+		{
+			get
+			{
+				return _overloads.AsReadOnly();
+			}
+		}
 
 		internal MethodGroupExpression(Delegate overload)
 		{
@@ -50,7 +56,7 @@ namespace DynamicExpresso
 
 		internal void AddOverload(Delegate overload)
 		{
-			_overloads.Add(Constant(overload));
+			_overloads.Add(overload);
 		}
 	}
 }

--- a/src/DynamicExpresso.Core/Identifier.cs
+++ b/src/DynamicExpresso.Core/Identifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace DynamicExpresso
@@ -18,6 +19,38 @@ namespace DynamicExpresso
 
 			Expression = expression;
 			Name = name;
+		}
+	}
+
+	internal class FunctionIdentifier : Identifier
+	{
+		internal FunctionIdentifier(string name, Delegate value) : base(name, new MethodGroupExpression(value))
+		{
+		}
+
+		internal void AddOverload(Delegate overload)
+		{
+			((MethodGroupExpression)Expression).AddOverload(overload);
+		}
+	}
+
+	/// <summary>
+	/// Custom expression that simulates a method group (ie. a group of methods with the same name).
+	/// </summary>
+	internal class MethodGroupExpression : Expression
+	{
+		private readonly List<Expression> _overloads = new List<Expression>();
+
+		internal IReadOnlyCollection<Expression> Overloads => _overloads.AsReadOnly();
+
+		internal MethodGroupExpression(Delegate overload)
+		{
+			AddOverload(overload);
+		}
+
+		internal void AddOverload(Delegate overload)
+		{
+			_overloads.Add(Constant(overload));
 		}
 	}
 }

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -145,7 +145,19 @@ namespace DynamicExpresso
 		/// <returns></returns>
 		public Interpreter SetFunction(string name, Delegate value)
 		{
-			return SetVariable(name, value);
+			if (string.IsNullOrWhiteSpace(name))
+				throw new ArgumentNullException(nameof(name));
+
+			if (_settings.Identifiers.TryGetValue(name, out var identifier) && identifier is FunctionIdentifier fIdentifier)
+			{
+				fIdentifier.AddOverload(value);
+			}
+			else
+			{
+				SetIdentifier(new FunctionIdentifier(name, value));
+			}
+
+			return this;
 		}
 
 		/// <summary>

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -862,13 +862,11 @@ namespace DynamicExpresso.Parsing
 			var args = ParseArgumentList();
 
 			// find all the delegates that can be used with the provided arguments
-			// note: we don't use PrepareDelegateInvoke because it modifies the argument list, 
-			// and it will prevent the algorithm from finding ambiguous calls
 			var candidates = methodGroup.Overloads
 				.Select(_ => new
 				{
-					DelegateExp = _,
-					ApplicableMethods = FindMethods(_.Type, "Invoke", false, args)
+					DelegateExp = Expression.Constant(_),
+					ApplicableMethods = FindBestMethod(new[] { _.Method }, args)
 				})
 				.Where(_ => _.ApplicableMethods.Length == 1)
 				.ToList();
@@ -1965,6 +1963,10 @@ namespace DynamicExpresso.Parsing
 				// we found a matching user defined operator on either type, but it might be the same method
 				if (userDefinedOperator != null && rightOperator != null && !ReferenceEquals(userDefinedOperator.MethodBase, rightOperator.MethodBase))
 					throw error;
+
+				// we didn't find an operator on the left type, but we found one on the right type
+				if (userDefinedOperator == null && rightOperator != null)
+					userDefinedOperator = rightOperator;
 			}
 
 			return userDefinedOperator;

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1963,10 +1963,6 @@ namespace DynamicExpresso.Parsing
 				// we found a matching user defined operator on either type, but it might be the same method
 				if (userDefinedOperator != null && rightOperator != null && !ReferenceEquals(userDefinedOperator.MethodBase, rightOperator.MethodBase))
 					throw error;
-
-				// we didn't find an operator on the left type, but we found one on the right type
-				if (userDefinedOperator == null && rightOperator != null)
-					userDefinedOperator = rightOperator;
 			}
 
 			return userDefinedOperator;

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -101,6 +101,17 @@ namespace DynamicExpresso.Resources {
         }
 
         /// <summary>
+		/// Looks up a localized string similar to Ambiguous invocation of delegate (multiple overloads found).
+        /// </summary>
+        internal static string AmbiguousDelegateInvocation
+		{
+			get
+			{
+				return ResourceManager.GetString("AmbiguousDelegateInvocation", resourceCulture);
+			}
+		}
+
+        /// <summary>
         ///   Looks up a localized string similar to Argument list incompatible with delegate expression.
         /// </summary>
         internal static string ArgsIncompatibleWithDelegate {

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -240,4 +240,7 @@
   <data name="AmbiguousUnaryOperatorInvocation" xml:space="preserve">
     <value>Ambiguous invocation of user defined operator '{0}' in type '{1}'</value>
   </data>
+  <data name="AmbiguousDelegateInvocation" xml:space="preserve">
+    <value>Ambiguous invocation of delegate (multiple overloads found)</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -185,6 +185,21 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Keywords_with_non_ambiguous_delegates()
+		{
+			Func<double, string> ambiguous1 = (val) => "double";
+			Func<int, string> ambiguous2 = (val) => "integer";
+
+			var interpreter = new Interpreter();
+			interpreter.SetFunction("MyFunc", ambiguous1);
+			interpreter.SetFunction("MyFunc", ambiguous2);
+
+			// there should be no ambiguous exception: int can implicitly be converted to double, 
+			// but there's a perfect match 
+			Assert.AreEqual("integer", interpreter.Eval("MyFunc(5)"));
+		}
+
+		[Test]
 		public void Set_function_With_Object_Params()
 		{
 			var target = new Interpreter();

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -2,6 +2,8 @@
 using NUnit.Framework;
 using System.Linq.Expressions;
 using DynamicExpresso.Exceptions;
+using System.Linq;
+using System.Reflection;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -180,6 +182,26 @@ namespace DynamicExpresso.UnitTest
 
 			// call resolved to the string overload
 			Assert.AreEqual("test", interpreter.Eval("MyFunc(\"test\")"));
+		}
+
+		[Test]
+		public void Set_function_With_Object_Params()
+		{
+			var target = new Interpreter();
+
+			// import static method with params array 
+			var methodInfo = typeof(VariablesTest).GetMethod("Sum", BindingFlags.Static | BindingFlags.NonPublic);
+			var types = methodInfo.GetParameters().Select(p => p.ParameterType).Concat(new[] { methodInfo.ReturnType });
+			var del = methodInfo.CreateDelegate(Expression.GetDelegateType(types.ToArray()));
+			target.SetFunction(methodInfo.Name, del);
+
+			// the imported Sum function can be called with any parameters
+			Assert.AreEqual(6, target.Eval<int>("Sum(1, 2, 3)"));
+		}
+
+		internal static int Sum(params int[] integers)
+		{
+			return integers.Sum();
 		}
 	}
 }


### PR DESCRIPTION
This is an attempt to fix #82, without changing the public interface. 

The idea is to use a custom identifier for functions, that rely on a dummy, custom, Linq Expression that represents the list of possible delegates. During the method invocation resolution, we detect this custom Expression, and check each possible overload to see if it matches the argument list.

The unit test is:

```
[Test]
public void Keywords_with_overloaded_delegates()
{
	Func<decimal, decimal> roundFunction1 = (userNumber) => Math.Round(userNumber);
	Func<decimal, int, decimal> roundFunction2 = (userNumber, decimals) => Math.Round(userNumber, decimals);

	var interpreter = new Interpreter();
	interpreter.SetFunction("ROUND", roundFunction1);
	interpreter.SetFunction("ROUND", roundFunction2);

	Assert.AreEqual(3.13M, interpreter.Eval("ROUND(3.12789M, 2)"));
	Assert.AreEqual(3M, interpreter.Eval("ROUND(3.12789M)"));
}
```