### PR TITLE
Fix #144: consider a delegate's invoke methods

### DIFF
--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.0;net461;net45</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net461;net45</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>		
 	</PropertyGroup>

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -210,6 +210,12 @@ namespace DynamicExpresso.UnitTest
 			var del = methodInfo.CreateDelegate(Expression.GetDelegateType(types.ToArray()));
 			target.SetFunction(methodInfo.Name, del);
 
+			Assert.IsNotNull(del.Method.GetParameters()[0].GetCustomAttribute<ParamArrayAttribute>());
+
+			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance;
+			var invokeMethod = (MethodInfo)(del.GetType().FindMembers(MemberTypes.Method, flags, Type.FilterName, "Invoke")[0]);
+			Assert.IsNull(invokeMethod.GetParameters()[0].GetCustomAttribute<ParamArrayAttribute>()); // should be not null!
+
 			// the imported Sum function can be called with any parameters
 			Assert.AreEqual(6, target.Eval<int>("Sum(1, 2, 3)"));
 		}


### PR DESCRIPTION
This fixes #144 by taking a delegate's invoke methods into account while resolving the method invocation of a function defined via `SetFunction`.