### PR TITLE
No longer stop parsing an expression after invoking a custom function

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -514,9 +514,8 @@ namespace DynamicExpresso.Parsing
 						return ParseLambdaInvocation(lambda, tokenPos);
 
 					if (expr is MethodGroupExpression methodGroup)
-						return ParseMethodGroupInvocation(methodGroup, tokenPos);
-
-					if (typeof(Delegate).IsAssignableFrom(expr.Type))
+						expr = ParseMethodGroupInvocation(methodGroup, tokenPos);
+					else if (typeof(Delegate).IsAssignableFrom(expr.Type))
 						expr = ParseDelegateInvocation(expr, tokenPos);
 					else
 						throw CreateParseException(tokenPos, ErrorMessages.InvalidMethodCall, GetTypeName(expr.Type));

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -140,6 +140,19 @@ namespace DynamicExpresso.UnitTest
 			Assert.False((bool)interpreter.Eval("GFunction()"));
 		}
 
+		[Test]
+		public void GitHub_Issue_148()
+		{
+			Func<object[], double, double, object[]> subArray = (entries, skipFirst, skipLast) => entries.Take(entries.Length - (int)skipLast).Skip((int)skipFirst).ToArray();
+
+			var target = new Interpreter();
+
+			target.SetVariable("arr1", new object[] { 1d, 2d, 3d });
+			target.SetFunction("SubArray", subArray);
+
+			Assert.AreEqual(2, target.Eval("SubArray(arr1, 1, 1).First()"));
+		}
+
 
 #if NETCOREAPP2_1_OR_GREATER
 


### PR DESCRIPTION
Fix #148.

#138 introduced a regression when chaining method calls after the invocation of a custom function registered via `SetFunction` (e.g. `MyFunc().First()`): the parsing of the expression was stopped after the method call.