### PR TITLE
Bind dynamic properties and methods of strongly typed classes

### DIFF
--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -35,7 +35,9 @@ namespace DynamicExpresso
 		{
 			var caseInsensitive = options.HasFlag(InterpreterOptions.CaseInsensitive);
 
-			_settings = new ParserSettings(caseInsensitive);
+			var lateBindObject = options.HasFlag(InterpreterOptions.LateBindObject);
+
+			_settings = new ParserSettings(caseInsensitive, lateBindObject);
 
 			if ((options & InterpreterOptions.SystemKeywords) == InterpreterOptions.SystemKeywords)
 			{

--- a/src/DynamicExpresso.Core/InterpreterOptions.cs
+++ b/src/DynamicExpresso.Core/InterpreterOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DynamicExpresso
 {
@@ -22,6 +22,10 @@ namespace DynamicExpresso
 		/// Variables and parameters names are case insensitive.
 		/// </summary>
 		CaseInsensitive = 8,
+		/// <summary>
+		/// Allow treating expressions of type Object as dynamic
+		/// </summary>		
+		LateBindObject = 16,
 		/// <summary>
 		/// Load all default configurations: PrimitiveTypes + SystemKeywords + CommonTypes
 		/// </summary>

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1384,9 +1384,11 @@ namespace DynamicExpresso.Parsing
 			return typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type);
 		}
 
-		private static bool IsDynamicExpression(Expression instance)
+		private bool IsDynamicExpression(Expression instance)
 		{
-			return instance != null && instance.NodeType == ExpressionType.Dynamic;
+			return instance != null &&
+				(instance.NodeType == ExpressionType.Dynamic ||
+				(_arguments.Settings.LateBindObject && instance.Type == typeof(object)));
 		}
 
 		private static Type GetNonNullableType(Type type)

--- a/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -10,9 +10,11 @@ namespace DynamicExpresso.Parsing
 		private readonly Dictionary<string, ReferenceType> _knownTypes;
 		private readonly HashSet<MethodInfo> _extensionMethods;
 		
-		public ParserSettings(bool caseInsensitive)
+		public ParserSettings(bool caseInsensitive,bool lateBindObject)
 		{
 			CaseInsensitive = caseInsensitive;
+
+			LateBindObject = lateBindObject;
 
 			KeyComparer = CaseInsensitive ? StringComparer.InvariantCultureIgnoreCase : StringComparer.InvariantCulture;
 
@@ -27,6 +29,8 @@ namespace DynamicExpresso.Parsing
 			AssignmentOperators = AssignmentOperators.All;
 
 			DefaultNumberType = DefaultNumberType.Default;
+
+			
 		}
 
 		public IDictionary<string, ReferenceType> KnownTypes
@@ -45,6 +49,12 @@ namespace DynamicExpresso.Parsing
 		}
 
 		public bool CaseInsensitive
+		{
+			get;
+			private set;
+		}
+
+		public bool LateBindObject
 		{
 			get;
 			private set;
@@ -73,5 +83,7 @@ namespace DynamicExpresso.Parsing
 			get;
 			set;
 		}
+
+		
 	}
 }


### PR DESCRIPTION
This is a follow up to my last pull request. 
Dynamic properties and methods of strongly type classes are currently not being recognized as such because the resulting expression if of type Object instead of a dynamic expression. 
The proposed change is to treat expressions on boxed objects as dynamic, allowing late binding.
I've included a test case of a particular use case of mine that was failing otherwise.