### PR TITLE
Prevent multiple registration of the same delegate with the same name

### DIFF
--- a/src/DynamicExpresso.Core/Identifier.cs
+++ b/src/DynamicExpresso.Core/Identifier.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
@@ -56,7 +56,9 @@ namespace DynamicExpresso
 
 		internal void AddOverload(Delegate overload)
 		{
-			_overloads.Add(overload);
+			// don't register the same overload twice
+			if (_overloads.IndexOf(overload) == -1)
+				_overloads.Add(overload);
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using System.Linq.Expressions;
 using DynamicExpresso.Exceptions;
@@ -135,6 +135,17 @@ namespace DynamicExpresso.UnitTest
 		{
 			Func<double, double, double> pow = (x, y) => Math.Pow(x, y);
 			var target = new Interpreter()
+									.SetFunction("pow", pow);
+
+			Assert.AreEqual(9.0, target.Eval("pow(3, 2)"));
+		}
+
+		[Test]
+		public void Keywords_with_same_overload_twice()
+		{
+			Func<double, double, double> pow = (x, y) => Math.Pow(x, y);
+			var target = new Interpreter()
+									.SetFunction("pow", pow)
 									.SetFunction("pow", pow);
 
 			Assert.AreEqual(9.0, target.Eval("pow(3, 2)"));


### PR DESCRIPTION
Fix one of the issue highlighted by #157 