### PR TITLE
Using ?. and ?[ operators with nullable types

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -652,7 +652,9 @@ namespace DynamicExpresso.Parsing
 
 					// ?. operator changes value types to nullable types
 					var memberAccess = GenerateNullableTypeConversion(ParseMemberAccess(null, expr));
-					expr = GenerateConditional(GenerateEqual(expr, ParserConstants.NullLiteralExpression), ParserConstants.NullLiteralExpression, memberAccess, _token.pos);
+					var nullExpr = ParserConstants.NullLiteralExpression;
+					CheckAndPromoteOperands(typeof(ParseSignatures.IEqualitySignatures), ref expr, ref nullExpr);
+					expr = GenerateConditional(GenerateEqual(expr, nullExpr), ParserConstants.NullLiteralExpression, memberAccess, _token.pos);
 				}
 				else if (_token.id == TokenId.OpenBracket)
 				{
@@ -662,7 +664,9 @@ namespace DynamicExpresso.Parsing
 				{
 					// ?[ operator changes value types to nullable types
 					var elementAccess = GenerateNullableTypeConversion(ParseElementAccess(expr));
-					expr = GenerateConditional(GenerateEqual(expr, ParserConstants.NullLiteralExpression), ParserConstants.NullLiteralExpression, elementAccess, _token.pos);
+					var nullExpr = ParserConstants.NullLiteralExpression;
+					CheckAndPromoteOperands(typeof(ParseSignatures.IEqualitySignatures), ref expr, ref nullExpr);
+					expr = GenerateConditional(GenerateEqual(expr, nullExpr), ParserConstants.NullLiteralExpression, elementAccess, _token.pos);
 				}
 				else if (_token.id == TokenId.OpenParen)
 				{

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -330,5 +330,19 @@ namespace DynamicExpresso.UnitTest
 			// must throw, because scope.ValueInt is not a nullable type
 			Assert.Throws<ParseException>(() => interpreter.Eval<bool>("scope.ArrInt[0].HasValue"));
 		}
+
+		[Test]
+		public void GitHub_Issue_169_quatro()
+		{
+			var interpreter = new Interpreter();
+
+			interpreter.SetVariable("x", (int?)null);
+			var result = interpreter.Eval<string>("x?.ToString()");
+			Assert.IsNull(result);
+
+			interpreter.SetVariable("x", (int?)56);
+			result = interpreter.Eval<string>("x?.ToString()");
+			Assert.AreEqual("56", result);
+		}
 	}
 }


### PR DESCRIPTION
`GenerateNullableTypeConversion` ensures a nullable type isn't converted to a nullable of nullable.
I've also added more test cases.

Fixes #169