### PR TITLE
Improve generic type parsing and referencing

### DIFF
--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -244,7 +244,7 @@
     <value>Ambiguous invocation of delegate (multiple overloads found)</value>
   </data>
   <data name="CloseCurlyBracketExpected" xml:space="preserve">
-    <value>'}' expected</value>
+    <value>'}}' expected</value>
   </data>
   <data name="OpenCurlyBracketExpected" xml:space="preserve">
     <value>'{{' expected</value>

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -247,7 +247,7 @@
     <value>'}' expected</value>
   </data>
   <data name="OpenCurlyBracketExpected" xml:space="preserve">
-    <value>'{' expected</value>
+    <value>'{{' expected</value>
   </data>
   <data name="EqualExpected" xml:space="preserve">
     <value>'=' expected</value>

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using DynamicExpresso.Exceptions;
 using NUnit.Framework;
 
@@ -77,6 +77,31 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.AreEqual(new MyClass() { StrProp = "test", IntField = 5, }, target.Eval("new MyClass() { StrProp = \"test\", IntField = 5, }"));
 			Assert.AreEqual(new MyClass() { StrProp = "test", IntField = 5 }, target.Eval("new MyClass() { StrProp = \"test\", IntField = 5 }"));
+		}
+
+		[Test]
+		public void Constructor_invocation_generics()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Tuple<>));
+			target.Reference(typeof(Tuple<,>));
+			target.Reference(typeof(Tuple<,,>));
+			Assert.AreEqual(1, target.Eval("new Tuple<int>(1).Item1"));
+			Assert.AreEqual("My str item", target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"));
+			Assert.AreEqual(3, target.Eval("new Tuple<int, int, int>(1, 2, 3).Item3"));
+		}
+
+		[Test]
+		public void Constructor_invocation_named_generics()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Tuple<,>), "Tuple");
+			Assert.AreEqual("My str item", target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"));
+
+			target.Reference(typeof(Tuple<>), "Tuple1");
+			target.Reference(typeof(Tuple<,,>), "Tuple3");
+			Assert.AreEqual(1, target.Eval("new Tuple1<int>(1).Item1"));
+			Assert.AreEqual(3, target.Eval("new Tuple3<int, int, int>(1, 2, 3).Item3"));
 		}
 
 		[Test]

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -92,6 +92,18 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Constructor_invocation_named_generics_with_arity()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Tuple<>), "Toto`1");
+			target.Reference(typeof(Tuple<,>), "Toto`2");
+			target.Reference(typeof(Tuple<,,>), "Toto`3");
+			Assert.AreEqual(1, target.Eval("new Toto<int>(1).Item1"));
+			Assert.AreEqual("My str item", target.Eval("new Toto<int, string>(5, \"My str item\").Item2"));
+			Assert.AreEqual(3, target.Eval("new Toto<int, int, int>(1, 2, 3).Item3"));
+		}
+
+		[Test]
 		public void Constructor_invocation_named_generics()
 		{
 			var target = new Interpreter();

--- a/test/DynamicExpresso.UnitTest/OperatorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/OperatorsTest.cs
@@ -103,6 +103,18 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Typeof_Operator_Generics_Arity()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Tuple<>));
+			target.Reference(typeof(Tuple<,>));
+			target.Reference(typeof(Tuple<,,>));
+			Assert.AreEqual(typeof(Tuple<>), target.Eval("typeof(Tuple<>)"));
+			Assert.AreEqual(typeof(Tuple<,>), target.Eval("typeof(Tuple<,>)"));
+			Assert.AreEqual(typeof(Tuple<,,>), target.Eval("typeof(Tuple<,,>)"));
+		}
+
+		[Test]
 		public void Is_Operator()
 		{
 			object a = "string value";
@@ -118,6 +130,23 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(b is string, target.Eval("b is string"));
 			// ReSharper disable once ConditionIsAlwaysTrueOrFalse
 			Assert.AreEqual(b is int, target.Eval("b is int"));
+		}
+
+		[Test]
+		public void Is_Operator_Generics()
+		{
+			object a = Tuple.Create(1);
+			object b = Tuple.Create(1, 2);
+			var target = new Interpreter()
+				.SetVariable("a", a, typeof(object))
+				.SetVariable("b", b, typeof(object));
+
+			target.Reference(typeof(Tuple<>));
+			target.Reference(typeof(Tuple<,>));
+
+			Assert.AreEqual(true, target.Eval("a is Tuple<int>"));
+			Assert.AreEqual(typeof(bool), target.Parse("a is Tuple<int>").ReturnType);
+			Assert.AreEqual(true, target.Eval("b is Tuple<int,int>"));
 		}
 
 		[Test]


### PR DESCRIPTION
The arity of the generic type is now considered when trying to get the reference type (e.g. `Tuple<,,>` is now looked up as ``Tuple`3`` during parsing).

That means it's possible to write:

```c#
var target = new Interpreter();
target.Reference(typeof(Tuple<>));
target.Reference(typeof(Tuple<,>));
target.Reference(typeof(Tuple<,,>));
Assert.AreEqual(1, target.Eval("new Tuple<int>(1).Item1"));
Assert.AreEqual("My str item", target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"));
Assert.AreEqual(3, target.Eval("new Tuple<int, int, int>(1, 2, 3).Item3"));
```

The old way is still working, but in that case you need to add the arity yourself:

```c#
var target = new Interpreter();
target.Reference(typeof(Tuple<>), "Toto`1");
target.Reference(typeof(Tuple<,>), "Toto`2");
target.Reference(typeof(Tuple<,,>), "Toto`3");
Assert.AreEqual(1, target.Eval("new Toto<int>(1).Item1"));
Assert.AreEqual("My str item", target.Eval("new Toto<int, string>(5, \"My str item\").Item2"));
Assert.AreEqual(3, target.Eval("new Toto<int, int, int>(1, 2, 3).Item3"));
```

I took this opportunity to also centralize the way types are parsed, so that it's consistent everywhere.

Fixes #174 