### PR TITLE
Additional Performance Improvements

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -67,7 +67,7 @@ namespace DynamicExpresso.Parsing
 		{
 			Expression expr = ParseExpressionSegment(_arguments.ExpressionReturnType);
 
-			ValidateToken(TokenId.End, ErrorMessages.SyntaxError);
+			ValidateToken(TokenId.End, ErrorMessage.SyntaxError);
 			return expr;
 		}
 
@@ -170,7 +170,7 @@ namespace DynamicExpresso.Parsing
 			var parameters = _token.id != TokenId.CloseParen ? ParseLambdaParameters() : new ParameterWithPosition[0];
 			if (hasOpenParen)
 			{
-				ValidateToken(TokenId.CloseParen, ErrorMessages.CloseParenOrCommaExpected);
+				ValidateToken(TokenId.CloseParen, ErrorMessage.CloseParenOrCommaExpected);
 				NextToken();
 			}
 
@@ -255,7 +255,7 @@ namespace DynamicExpresso.Parsing
 			{
 				NextToken();
 				var expr1 = ParseExpressionSegment();
-				ValidateToken(TokenId.Colon, ErrorMessages.ColonExpected);
+				ValidateToken(TokenId.Colon, ErrorMessage.ColonExpected);
 				NextToken();
 				var expr2 = ParseExpressionSegment();
 				expr = GenerateConditional(expr, expr1, expr2, errorPos);
@@ -991,10 +991,10 @@ namespace DynamicExpresso.Parsing
 
 		private Expression ParseParenExpression()
 		{
-			ValidateToken(TokenId.OpenParen, ErrorMessages.OpenParenExpected);
+			ValidateToken(TokenId.OpenParen, ErrorMessage.OpenParenExpected);
 			NextToken();
 			Expression innerParenthesesExpression = ParseExpressionSegment();
-			ValidateToken(TokenId.CloseParen, ErrorMessages.CloseParenOrOperatorExpected);
+			ValidateToken(TokenId.CloseParen, ErrorMessage.CloseParenOrOperatorExpected);
 
 			var constExp = innerParenthesesExpression as ConstantExpression;
 			if (constExp != null && constExp.Value is Type)
@@ -1108,11 +1108,11 @@ namespace DynamicExpresso.Parsing
 		{
 			NextToken();
 
-			ValidateToken(TokenId.OpenParen, ErrorMessages.OpenParenExpected);
+			ValidateToken(TokenId.OpenParen, ErrorMessage.OpenParenExpected);
 			NextToken();
 			ValidateToken(TokenId.Identifier);
 			var type = ParseKnownType();
-			ValidateToken(TokenId.CloseParen, ErrorMessages.CloseParenOrCommaExpected);
+			ValidateToken(TokenId.CloseParen, ErrorMessage.CloseParenOrCommaExpected);
 			NextToken();
 
 			return Expression.Default(type);
@@ -1162,7 +1162,7 @@ namespace DynamicExpresso.Parsing
 		private Expression ParseNew()
 		{
 			NextToken();
-			ValidateToken(TokenId.Identifier, ErrorMessages.IdentifierExpected);
+			ValidateToken(TokenId.Identifier, ErrorMessage.IdentifierExpected);
 
 			var newType = ParseKnownType();
 			var args = new Expression[0];
@@ -1181,7 +1181,7 @@ namespace DynamicExpresso.Parsing
 			else
 			{
 				// no aguments: expect an object initializer
-				ValidateToken(TokenId.OpenCurlyBracket, ErrorMessages.OpenCurlyBracketExpected);
+				ValidateToken(TokenId.OpenCurlyBracket, ErrorMessage.OpenCurlyBracketExpected);
 			}
 
 			var applicableConstructors = MethodResolution.FindBestMethod(newType.GetConstructors(), args);
@@ -1202,17 +1202,17 @@ namespace DynamicExpresso.Parsing
 
 		private Expression[] ParseArrayInitializerList()
 		{
-			return ParseArgumentList(TokenId.OpenCurlyBracket, ErrorMessages.OpenCurlyBracketExpected,
-				TokenId.CloseCurlyBracket, ErrorMessages.CloseCurlyBracketExpected,
+			return ParseArgumentList(TokenId.OpenCurlyBracket, ErrorMessage.OpenCurlyBracketExpected,
+				TokenId.CloseCurlyBracket, ErrorMessage.CloseCurlyBracketExpected,
 				allowTrailingComma: true);
 		}
 
 		private Expression ParseWithObjectInitializer(NewExpression newExpr, Type newType)
 		{
-			ValidateToken(TokenId.OpenCurlyBracket, ErrorMessages.OpenCurlyBracketExpected);
+			ValidateToken(TokenId.OpenCurlyBracket, ErrorMessage.OpenCurlyBracketExpected);
 			NextToken();
 			var initializedInstance = ParseMemberAndInitializerList(newExpr, newType);
-			ValidateToken(TokenId.CloseCurlyBracket, ErrorMessages.CloseCurlyBracketExpected);
+			ValidateToken(TokenId.CloseCurlyBracket, ErrorMessage.CloseCurlyBracketExpected);
 			NextToken();
 			return initializedInstance;
 		}
@@ -1249,7 +1249,7 @@ namespace DynamicExpresso.Parsing
 
 		private void ParsePossibleMemberBinding(Type newType, int originalPos, List<MemberBinding> bindingList, List<Expression> actions, ParameterExpression instance, bool allowCollectionInit)
 		{
-			ValidateToken(TokenId.Identifier, ErrorMessages.IdentifierExpected);
+			ValidateToken(TokenId.Identifier, ErrorMessage.IdentifierExpected);
 
 			var propertyOrFieldName = _token.text;
 			var member = _memberFinder.FindPropertyOrField(newType, propertyOrFieldName, false);
@@ -1282,7 +1282,7 @@ namespace DynamicExpresso.Parsing
 			}
 			NextToken();
 
-			ValidateToken(TokenId.Equal, ErrorMessages.EqualExpected);
+			ValidateToken(TokenId.Equal, ErrorMessage.EqualExpected);
 			NextToken();
 
 			var value = ParseExpressionSegment();
@@ -1323,7 +1323,7 @@ namespace DynamicExpresso.Parsing
 					SetTextPos(pos);
 					ParseExpressionSegment();
 				}
-				actions.Add(ParseMethodInvocation(newType, instance, _token.pos, "Add", TokenId.OpenCurlyBracket, ErrorMessages.OpenCurlyBracketExpected, TokenId.CloseCurlyBracket, ErrorMessages.CloseCurlyBracketExpected));
+				actions.Add(ParseMethodInvocation(newType, instance, _token.pos, "Add", TokenId.OpenCurlyBracket, ErrorMessage.OpenCurlyBracketExpected, TokenId.CloseCurlyBracket, ErrorMessage.CloseCurlyBracketExpected));
 			}
 			else
 			{
@@ -1499,7 +1499,7 @@ namespace DynamicExpresso.Parsing
 					NextToken();
 				}
 
-				ValidateToken(TokenId.CloseBracket, ErrorMessages.CloseBracketOrCommaExpected);
+				ValidateToken(TokenId.CloseBracket, ErrorMessage.CloseBracketOrCommaExpected);
 				ranks.Push(rank);
 				NextToken();
 			}
@@ -1527,7 +1527,7 @@ namespace DynamicExpresso.Parsing
 				args = new List<Type>(new Type[arity]);
 			}
 
-			ValidateToken(TokenId.GreaterThan, ErrorMessages.CloseTypeArgumentListExpected);
+			ValidateToken(TokenId.GreaterThan, ErrorMessage.CloseTypeArgumentListExpected);
 			return args;
 		}
 
@@ -1569,7 +1569,7 @@ namespace DynamicExpresso.Parsing
 				return Expression.Constant(type);
 			}
 
-			ValidateToken(TokenId.Dot, ErrorMessages.DotOrOpenParenExpected);
+			ValidateToken(TokenId.Dot, ErrorMessage.DotOrOpenParenExpected);
 			NextToken();
 			return ParseMemberAccess(type, null);
 		}
@@ -1684,11 +1684,11 @@ namespace DynamicExpresso.Parsing
 
 		private Expression ParseMethodInvocation(Type type, Expression instance, int errorPos, string methodName)
 		{
-			return ParseMethodInvocation(type, instance, errorPos, methodName, TokenId.OpenParen, ErrorMessages.OpenParenExpected, TokenId.CloseParen, ErrorMessages.CloseParenOrCommaExpected);
+			return ParseMethodInvocation(type, instance, errorPos, methodName, TokenId.OpenParen, ErrorMessage.OpenParenExpected, TokenId.CloseParen, ErrorMessage.CloseParenOrCommaExpected);
 
 		}
 
-		private Expression ParseMethodInvocation(Type type, Expression instance, int errorPos, string methodName, TokenId open, string openExpected, TokenId close, string closeExpected)
+		private Expression ParseMethodInvocation(Type type, Expression instance, int errorPos, string methodName, TokenId open, ErrorMessage openExpected, TokenId close, ErrorMessage closeExpected)
 		{
 			var args = ParseArgumentList(open, openExpected, close, closeExpected);
 
@@ -1818,8 +1818,8 @@ namespace DynamicExpresso.Parsing
 			return Expression.Dynamic(new LateGetIndexCallSiteBinder(), typeof(object), argsDynamic);
 		}
 
-		private Expression[] ParseArgumentList(TokenId openToken, string missingOpenTokenMsg,
-			TokenId closeToken, string missingCloseTokenMsg,
+		private Expression[] ParseArgumentList(TokenId openToken, ErrorMessage missingOpenTokenMsg,
+			TokenId closeToken, ErrorMessage missingCloseTokenMsg,
 			bool allowTrailingComma = false)
 		{
 			ValidateToken(openToken, missingOpenTokenMsg);
@@ -1840,15 +1840,15 @@ namespace DynamicExpresso.Parsing
 
 		private Expression[] ParseArgumentList()
 		{
-			return ParseArgumentList(TokenId.OpenParen, ErrorMessages.OpenParenExpected,
-				TokenId.CloseParen, ErrorMessages.CloseParenOrCommaExpected);
+			return ParseArgumentList(TokenId.OpenParen, ErrorMessage.OpenParenExpected,
+				TokenId.CloseParen, ErrorMessage.CloseParenOrCommaExpected);
 		}
 
 		private Expression ParseElementAccess(Expression expr)
 		{
 			var errorPos = _token.pos;
-			var args = ParseArgumentList(TokenId.OpenBracket, ErrorMessages.OpenParenExpected,
-				TokenId.CloseBracket, ErrorMessages.CloseBracketOrCommaExpected);
+			var args = ParseArgumentList(TokenId.OpenBracket, ErrorMessage.OpenParenExpected,
+				TokenId.CloseBracket, ErrorMessage.CloseBracketOrCommaExpected);
 			if (expr.Type.IsArray)
 			{
 				if (expr.Type.GetArrayRank() != args.Length)
@@ -2571,7 +2571,7 @@ namespace DynamicExpresso.Parsing
 
 		private string GetIdentifier()
 		{
-			ValidateToken(TokenId.Identifier, ErrorMessages.IdentifierExpected);
+			ValidateToken(TokenId.Identifier, ErrorMessage.IdentifierExpected);
 			var id = _token.text;
 			if (id.Length > 1 && id[0] == '@')
 				id = id.Substring(1);
@@ -2585,7 +2585,7 @@ namespace DynamicExpresso.Parsing
 		}
 
 		// ReSharper disable once UnusedParameter.Local
-		private void ValidateToken(TokenId t, string errorMessage)
+		private void ValidateToken(TokenId t, ErrorMessage errorMessage)
 		{
 			if (_token.id != t)
 				throw ParseException.Create(_token.pos, errorMessage);

--- a/src/DynamicExpresso.Core/Reflection/MemberFinder.cs
+++ b/src/DynamicExpresso.Core/Reflection/MemberFinder.cs
@@ -49,7 +49,7 @@ namespace DynamicExpresso.Reflection
 
 			public int GetHashCode(MemberTypeKey obj)
 			{
-				return obj._type.GetHashCode() ^ obj._flags.GetHashCode() ^ StringComparer.InvariantCulture.GetHashCode(obj._memberName);
+				return obj._type.GetHashCode() ^ obj._flags.GetHashCode() ^ StringComparer.OrdinalIgnoreCase.GetHashCode(obj._memberName);
 			}
 		}
 
@@ -106,10 +106,6 @@ namespace DynamicExpresso.Reflection
 						members = subMembers;
 					}
 				}
-			}
-			if (members.Length == 0)
-			{
-				members = Array.Empty<MemberInfo>();
 			}
 			_members[key] = members;
 			return members;
@@ -211,7 +207,7 @@ namespace DynamicExpresso.Reflection
 
 		private static IEnumerable<Type> AddInterface(HashSet<Type> types, Type type)
 		{
-			if (!types.Contains(type))
+			if (types.Add(type))
 			{
 				yield return type;
 				foreach (var i in type.GetInterfaces().SelectMany(x => AddInterface(types, x)))

--- a/src/DynamicExpresso.Core/Reflection/MemberFinder.cs
+++ b/src/DynamicExpresso.Core/Reflection/MemberFinder.cs
@@ -9,15 +9,61 @@ namespace DynamicExpresso.Reflection
 {
 	internal class MemberFinder
 	{
+		private struct MemberTypeKey
+		{
+			public Type _type;
+			public string _memberName;
+			public BindingFlags _flags;
+
+			public MemberTypeKey(Type type, string memberName, BindingFlags flags)
+			{
+				_type = type;
+				_memberName = memberName;
+				_flags = flags;
+			}
+		}
+
+		private class MemberTypeKeyEqualityComparer : IEqualityComparer<MemberTypeKey>
+		{
+			public static readonly MemberTypeKeyEqualityComparer Instance = new MemberTypeKeyEqualityComparer();
+
+			public bool Equals(MemberTypeKey x, MemberTypeKey y)
+			{
+				return x._type.Equals(y._type) && x._flags == y._flags && x._memberName.Equals(y._memberName, StringComparison.Ordinal);
+			}
+
+
+			public int GetHashCode(MemberTypeKey obj)
+			{
+				return obj._type.GetHashCode() ^ obj._flags.GetHashCode() ^ obj._memberName.GetHashCode();
+			}
+		}
+
+		private class MemberTypeKeyCaseInsensitiveEqualityComparer : IEqualityComparer<MemberTypeKey>
+		{
+			public static readonly MemberTypeKeyCaseInsensitiveEqualityComparer Instance = new MemberTypeKeyCaseInsensitiveEqualityComparer();
+			public bool Equals(MemberTypeKey x, MemberTypeKey y)
+			{
+				return x._type.Equals(y._type) && x._flags == y._flags && x._memberName.Equals(y._memberName, StringComparison.OrdinalIgnoreCase);
+			}
+
+			public int GetHashCode(MemberTypeKey obj)
+			{
+				return obj._type.GetHashCode() ^ obj._flags.GetHashCode() ^ StringComparer.InvariantCulture.GetHashCode(obj._memberName);
+			}
+		}
+
 		private readonly ParserArguments _arguments;
 		private readonly BindingFlags _bindingCase;
 		private readonly MemberFilter _memberFilterCase;
+		private readonly Dictionary<MemberTypeKey, MemberInfo[]> _members;
 
 		public MemberFinder(ParserArguments arguments)
 		{
 			_arguments = arguments;
 			_bindingCase = arguments.Settings.CaseInsensitive ? BindingFlags.IgnoreCase : BindingFlags.Default;
 			_memberFilterCase = arguments.Settings.CaseInsensitive ? Type.FilterNameIgnoreCase : Type.FilterName;
+			_members = new Dictionary<MemberTypeKey, MemberInfo[]>(arguments.Settings.CaseInsensitive ? (IEqualityComparer<MemberTypeKey>)MemberTypeKeyCaseInsensitiveEqualityComparer.Instance : MemberTypeKeyEqualityComparer.Instance);
 		}
 
 		public MemberInfo FindPropertyOrField(Type type, string memberName, bool staticAccess)
@@ -25,22 +71,61 @@ namespace DynamicExpresso.Reflection
 			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
 						(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
 
-			foreach (var t in SelfAndBaseTypes(type))
+			//Not looping here because FindMembers loops internally and returns us the highest level member
+			var members = FindMembers(type, MemberTypes.Property | MemberTypes.Field, flags, memberName);
+			if (members.Length != 0)
 			{
-				var members = t.FindMembers(MemberTypes.Property | MemberTypes.Field, flags, _memberFilterCase, memberName);
-				if (members.Length != 0)
-					return members[0];
+				return members[0];
 			}
 			return null;
+		}
+
+		private MemberInfo[] FindMembers(Type type, MemberTypes memberTypes, BindingFlags flags, string memberName)
+		{
+			var key = new MemberTypeKey(type, memberName, flags);
+			if (_members.TryGetValue(key, out var members))
+			{
+				if (members != null)
+				{
+					return members;
+				}
+			}
+			members = type.FindMembers(memberTypes, flags, _memberFilterCase, memberName);
+			if (members.Length == 0)
+			{
+				foreach (var v in SelfAndBaseTypes(type))
+				{
+					if (v == type)
+					{
+						continue;
+					}
+					var subMembers = FindMembers(v, memberTypes, flags, memberName);
+					if (members.Length == 0 && subMembers.Length > 0)
+					{
+						//We don't break here because there is a possibility that somebody outside here is also doing an additional tree prioritization (See FindMethods)
+						members = subMembers;
+					}
+				}
+			}
+			if (members.Length == 0)
+			{
+				members = Array.Empty<MemberInfo>();
+			}
+			_members[key] = members;
+			return members;
 		}
 
 		public IList<MethodData> FindMethods(Type type, string methodName, bool staticAccess, Expression[] args)
 		{
 			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
 						(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
+			//Yes, FindMembers loops internally, but there are certain circumstances where we end up also needing this
+			//An example is Type.GetMethods(), where there are multiple overloads on the base Type class
+			//and one override on a derived class.  The DeclaredOnly flag will return the single method on the derived class unless we go lower.
+			//The existing unit tests do pass if we get rid of DeclaredOnly and remove the loop, but I'm not sure of the actual impact that may have.
 			foreach (var t in SelfAndBaseTypes(type))
 			{
-				var members = t.FindMembers(MemberTypes.Method, flags, _memberFilterCase, methodName);
+				var members = FindMembers(t, MemberTypes.Method, flags, methodName);
 				var applicableMethods = MethodResolution.FindBestMethod(members.Cast<MethodBase>(), args);
 
 				if (applicableMethods.Count > 0)
@@ -100,14 +185,19 @@ namespace DynamicExpresso.Reflection
 		{
 			if (type.IsInterface)
 			{
-				var types = new List<Type>();
-				AddInterface(types, type);
+				var types = new HashSet<Type>();
+				foreach (var v in AddInterface(types, type))
+				{
+					yield return v;
+				}
 
-				types.Add(typeof(object));
-
-				return types;
+				yield return typeof(object);
+				yield break;
 			}
-			return SelfAndBaseClasses(type);
+			foreach (var t in SelfAndBaseClasses(type))
+			{
+				yield return t;
+			}
 		}
 
 		private static IEnumerable<Type> SelfAndBaseClasses(Type type)
@@ -119,14 +209,14 @@ namespace DynamicExpresso.Reflection
 			}
 		}
 
-		private static void AddInterface(List<Type> types, Type type)
+		private static IEnumerable<Type> AddInterface(HashSet<Type> types, Type type)
 		{
 			if (!types.Contains(type))
 			{
-				types.Add(type);
-				foreach (var t in type.GetInterfaces())
+				yield return type;
+				foreach (var i in type.GetInterfaces().SelectMany(x => AddInterface(types, x)))
 				{
-					AddInterface(types, t);
+					yield return i;
 				}
 			}
 		}

--- a/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
+++ b/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
@@ -95,7 +95,7 @@ namespace DynamicExpresso.Reflection
 
 		public static bool HasParamsArrayType(ParameterInfo parameterInfo)
 		{
-			return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
+			return parameterInfo.ParameterType.IsArray && parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
 		}
 
 		public static Type GetParameterType(ParameterInfo parameterInfo)

--- a/src/DynamicExpresso.Core/Resources/ErrorMessage.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessage.cs
@@ -9,8 +9,8 @@ namespace DynamicExpresso.Resources
 	/// </summary>
 	public class ErrorMessage
 	{
-		private string _message;
-		private Func<string> _getMessage;
+		private readonly string _message;
+		private readonly Func<string> _getMessage;
 
 		/// <summary>
 		/// Initializes this instance to return the provided message.

--- a/src/DynamicExpresso.Core/Resources/ErrorMessage.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessage.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DynamicExpresso.Resources
+{
+	/// <summary>
+	/// Used to provide a lazily accessed Error Message.
+	/// </summary>
+	public class ErrorMessage
+	{
+		private string _message;
+		private Func<string> _getMessage;
+
+		/// <summary>
+		/// Initializes this instance to return the provided message.
+		/// </summary>
+		/// <param name="message"></param>
+		public ErrorMessage(string message)
+		{
+			_message = message;
+			_getMessage = null;
+		}
+
+		/// <summary>
+		/// Initializes this instance to call the provided method to retrieve the message.
+		/// </summary>
+		/// <param name="message"></param>
+		public ErrorMessage(Func<string> message)
+		{
+			_message = null;
+			_getMessage = message;
+		}
+
+		/// <summary>
+		/// Returns the message this instance was initialized with.
+		/// </summary>
+		/// <returns></returns>
+		public override string ToString()
+		{
+			return _message ?? _getMessage();
+		}
+
+		public static implicit operator string(ErrorMessage message)
+		{
+			return message.ToString();
+		}
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.OpenCurlyBracketExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage OpenCurlyBracketExpected = new ErrorMessage(() => ErrorMessages.OpenCurlyBracketExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.OpenParenExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage OpenParenExpected = new ErrorMessage(() => ErrorMessages.OpenParenExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.CloseCurlyBracketExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage CloseCurlyBracketExpected = new ErrorMessage(() => ErrorMessages.CloseCurlyBracketExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.CloseParenOrCommaExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage CloseParenOrCommaExpected = new ErrorMessage(() => ErrorMessages.CloseParenOrCommaExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.CloseBracketOrCommaExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage CloseBracketOrCommaExpected = new ErrorMessage(() => ErrorMessages.CloseBracketOrCommaExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.SyntaxError"/>.
+		/// </summary>
+		public static readonly ErrorMessage SyntaxError = new ErrorMessage(() => ErrorMessages.SyntaxError);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.ColonExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage ColonExpected = new ErrorMessage(() => ErrorMessages.ColonExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.CloseParenOrOperatorExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage CloseParenOrOperatorExpected = new ErrorMessage(() => ErrorMessages.CloseParenOrOperatorExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.IdentifierExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage IdentifierExpected = new ErrorMessage(() => ErrorMessages.IdentifierExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.EqualExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage EqualExpected = new ErrorMessage(() => ErrorMessages.EqualExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.CloseTypeArgumentListExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage CloseTypeArgumentListExpected = new ErrorMessage(() => ErrorMessages.CloseTypeArgumentListExpected);
+
+		/// <summary>
+		/// The singleton instance that returns a call to <seealso cref="ErrorMessages.DotOrOpenParenExpected"/>.
+		/// </summary>
+		public static readonly ErrorMessage DotOrOpenParenExpected = new ErrorMessage(() => ErrorMessages.DotOrOpenParenExpected);
+	}
+}

--- a/src/DynamicExpresso.Core/Resources/ErrorMessage.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessage.cs
@@ -7,20 +7,9 @@ namespace DynamicExpresso.Resources
 	/// <summary>
 	/// Used to provide a lazily accessed Error Message.
 	/// </summary>
-	public class ErrorMessage
+	internal sealed class ErrorMessage
 	{
-		private readonly string _message;
 		private readonly Func<string> _getMessage;
-
-		/// <summary>
-		/// Initializes this instance to return the provided message.
-		/// </summary>
-		/// <param name="message"></param>
-		public ErrorMessage(string message)
-		{
-			_message = message;
-			_getMessage = null;
-		}
 
 		/// <summary>
 		/// Initializes this instance to call the provided method to retrieve the message.
@@ -28,7 +17,6 @@ namespace DynamicExpresso.Resources
 		/// <param name="message"></param>
 		public ErrorMessage(Func<string> message)
 		{
-			_message = null;
 			_getMessage = message;
 		}
 
@@ -38,7 +26,7 @@ namespace DynamicExpresso.Resources
 		/// <returns></returns>
 		public override string ToString()
 		{
-			return _message ?? _getMessage();
+			return _getMessage();
 		}
 
 		public static implicit operator string(ErrorMessage message)


### PR DESCRIPTION
As promised, in #349 I finally have my contribution to the performance wrapped up and ready to go.

The proposed changes break down into addressing the following profiling findings

1. A lot of time was spent in the call to ErrorMessages.[SomeErrorMessage] that was being provided to generic helper methods
2. HasParamsArrayType is in the hot path and spent a lot of time accessing code invisible to us
3. MemberFinder using the Type.FindMembers method also spent a good proportion of the time accessing code invisible to us

I also had the goal of improving the FindBestMethods logic to reduce List creation as much as possible.  Due to a couple of tests hitting very specific asserts I was unable to get rid of the List completely but the single list that is allocated will only have more than 2 items in extremely rare cases, whereas the old logic regularly could hit 10 or 11 that it then has to reprocess at the end.  Additionally, if we have already hit an EXACT match (no type converting, no params usage, etc.) of a method and a candidate method requires some kind of conversion we end the preparing of that method altogether.

Going forward I would like to break the usage of CheckMethodMatchAndPrepareIt logic into the two separate stages
1. Gather the best possible matching methods without any of the extra hinting that preparing adds to the process.
2. Prepare the methods and prune if needed.
However at this time I didn't have the time to really dig into that logic and figure out exactly when/why things happen.

The only thing I'm not sure on is if we would like the MemberFinder's caching to be something people can turn on/off.  I was thinking it is fine to keep on and not even expose that it is happening since the caching only lives per Eval or Parse call and does not persist across multiple calls (unlike the Ncalc library that statically caches its built expressions)

  My timings from the same benchmarking logic as show in #349 after improvements is

<!--StartFragment-->
Method | N | Mean | Error | StdDev
-- | -- | -- | -- | --
DynamicExpressoParsingOnly | 5 | 10,246.8 ns | 200.6 ns | 281.22 ns
DynamicExpressoEval | 5 | 184830.1 ns | 3602.97 ns | 5167.27 ns
NcalcEval | 5 | 784.3 ns | 15.46 ns | 26.25 ns
NcalcEvalNoCache | 5 | 11,609.5 ns | 202.24 ns | 179.28 ns
DynamicExpressoParsingOnly | 20 | 63,925.0 ns | 286.82 ns | 239.50 ns
DynamicExpressoEval | 20 | 314,246.6 ns | 1,869.79 ns | 1,561.36 ns
NcalcEval | 20 | 2,798.6 ns | 12.05 ns | 10.06 ns
NcalcEvalNoCache | 20 | 44130.1 ns | 398.75 ns | 372.99 ns

<!--EndFragment-->

<!--StartFragment-->
Timings from before my changes
Method | N | Mean | Error | StdDev     
-- | -- | -- | -- | --
| DynamicExpressoParsingOnly | 5  |  13,778.0 ns |   223.15 ns |   197.81 ns
| DynamicExpressoEval        | 5  | 191,236.9 ns | 3,764.84 ns | 5,635.04 ns
| NcalcEval                  | 5  |     755.8 ns |    14.41 ns |    15.42 ns
| NcalcEvalNoCache           | 5  |  11,846.7 ns |   232.50 ns |   258.42 ns
| DynamicExpressoParsingOnly | 20 |  57,399.6 ns |   576.39 ns |   481.31 ns
| DynamicExpressoEval        | 20 | 334,871.9 ns | 5,342.14 ns | 4,997.04 ns
| NcalcEval                  | 20 |   3,027.6 ns |    57.66 ns |    61.70 ns
| NcalcEvalNoCache           | 20 |  43,733.4 ns |   585.24 ns |   518.80 ns

<!--EndFragment-->


I'm not sure what's up with the DynamicExpressoParsingOnly N = 20 case since the Eval is proportionally faster.

