### PR TITLE
Add a more aggressive fast-path for `Invoke(object[])`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ stylecop.*
 ~$*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
+BenchmarkDotNet.Artifacts/
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/DynamicExpresso.sln
+++ b/DynamicExpresso.sln
@@ -12,23 +12,62 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{4088369E-A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicExpresso.Core", "src\DynamicExpresso.Core\DynamicExpresso.Core.csproj", "{C6B7C0D2-B84A-4307-9C61-D95613DB564D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmark", "benchmark", "{09EED85C-BE3C-7566-DC0E-2E8E43466740}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicExpresso.Benchmarks", "benchmark\DynamicExpresso.Benchmarks\DynamicExpresso.Benchmarks.csproj", "{394496C4-B878-4F0C-8471-2417F3205FC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Debug|x86.Build.0 = Debug|Any CPU
 		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Release|x64.Build.0 = Release|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{33157A92-C6B2-4A51-8262-1FEBFD6558BE}.Release|x86.Build.0 = Release|Any CPU
 		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Debug|x64.Build.0 = Debug|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Debug|x86.Build.0 = Debug|Any CPU
 		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Release|x64.ActiveCfg = Release|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Release|x64.Build.0 = Release|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Release|x86.ActiveCfg = Release|Any CPU
+		{C6B7C0D2-B84A-4307-9C61-D95613DB564D}.Release|x86.Build.0 = Release|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Debug|x64.Build.0 = Debug|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Debug|x86.Build.0 = Debug|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Release|x64.ActiveCfg = Release|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Release|x64.Build.0 = Release|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Release|x86.ActiveCfg = Release|Any CPU
+		{394496C4-B878-4F0C-8471-2417F3205FC8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{394496C4-B878-4F0C-8471-2417F3205FC8} = {09EED85C-BE3C-7566-DC0E-2E8E43466740}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A36C3463-448E-4051-AE87-A2994E36C1EC}

--- a/README.md
+++ b/README.md
@@ -560,6 +560,12 @@ or run unit tests for a specific project with a specific framework:
 
 Add `--logger:trx` to generate test results for VSTS.
 
+## Benchmarks
+
+This repository includes a BenchmarkDotNet project under `benchmark/DynamicExpresso.Benchmarks` to measure interpreter hot-paths.
+
+	dotnet run -c Release --project benchmark/DynamicExpresso.Benchmarks
+
 ## Release notes
 
 See [releases page](https://github.com/dynamicexpresso/DynamicExpresso/releases).

--- a/benchmark/DynamicExpresso.Benchmarks/DynamicExpresso.Benchmarks.csproj
+++ b/benchmark/DynamicExpresso.Benchmarks/DynamicExpresso.Benchmarks.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <ProjectReference Include="..\..\src\DynamicExpresso.Core\DynamicExpresso.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/benchmark/DynamicExpresso.Benchmarks/LambdaBenchmarks.cs
+++ b/benchmark/DynamicExpresso.Benchmarks/LambdaBenchmarks.cs
@@ -1,0 +1,79 @@
+using BenchmarkDotNet.Attributes;
+
+namespace DynamicExpresso.Benchmarks;
+
+[MemoryDiagnoser]
+public class LambdaBenchmarks
+{
+	private Interpreter _interpreter = null!;
+
+	private Lambda _lambda = null!;
+
+	private object[] _args = null!;
+	private Parameter[] _declared = null!;
+	private Parameter[] _parameterValues = null!;
+
+	private const int A = 1;
+	private const int B = 2;
+	private const int C = 3;
+	private const int D = 4;
+	private const int E = 5;
+	private const int F = 6;
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		_interpreter = new Interpreter();
+
+		_declared = new[]
+		{
+			new Parameter("a", typeof(int)),
+			new Parameter("b", typeof(int)),
+			new Parameter("c", typeof(int)),
+			new Parameter("d", typeof(int)),
+			new Parameter("e", typeof(int)),
+			new Parameter("f", typeof(int))
+		};
+
+		_lambda = _interpreter.Parse(
+			"((a + b) * c - (double)d / (e + f + 1)) + Math.Max(a, b)",
+			typeof(double),
+			_declared);
+
+		_args = new object[] { A, B, C, D, E, F };
+
+		_parameterValues = new[]
+		{
+			new Parameter("a", typeof(int), A),
+			new Parameter("b", typeof(int), B),
+			new Parameter("c", typeof(int), C),
+			new Parameter("d", typeof(int), D),
+			new Parameter("e", typeof(int), E),
+			new Parameter("f", typeof(int), F)
+		};
+	}
+
+	[Benchmark(Description = "Invoke cached lambda (object[])")]
+	public double Invoke_ObjectArray()
+	{
+		double sum = 0;
+		for (var i = 0; i < 100_000; i++)
+		{
+			sum += (double)_lambda.Invoke(_args);
+		}
+
+		return sum;
+	}
+
+	[Benchmark(Description = "Invoke cached lambda (IEnumerable<Parameter>)")]
+	public double Invoke_ParametersEnumerable()
+	{
+		double sum = 0;
+		for (var i = 0; i < 100_000; i++)
+		{
+			sum += (double)_lambda.Invoke(_parameterValues);
+		}
+
+		return sum;
+	}
+}

--- a/benchmark/DynamicExpresso.Benchmarks/LambdaBenchmarks.cs
+++ b/benchmark/DynamicExpresso.Benchmarks/LambdaBenchmarks.cs
@@ -5,6 +5,9 @@ namespace DynamicExpresso.Benchmarks;
 [MemoryDiagnoser]
 public class LambdaBenchmarks
 {
+	private const string ExpressionText =
+		"((a + b) * c - (double)d / (e + f + 1)) + Math.Max(a, b)";
+
 	private Interpreter _interpreter = null!;
 
 	private Lambda _lambda = null!;
@@ -36,7 +39,7 @@ public class LambdaBenchmarks
 		};
 
 		_lambda = _interpreter.Parse(
-			"((a + b) * c - (double)d / (e + f + 1)) + Math.Max(a, b)",
+			ExpressionText,
 			typeof(double),
 			_declared);
 
@@ -72,6 +75,18 @@ public class LambdaBenchmarks
 		for (var i = 0; i < 100_000; i++)
 		{
 			sum += (double)_lambda.Invoke(_parameterValues);
+		}
+
+		return sum;
+	}
+
+	[Benchmark(Description = "Eval (IEnumerable<Parameter>)")]
+	public double Eval_ParametersEnumerable()
+	{
+		double sum = 0;
+		for (var i = 0; i < 100_000; i++)
+		{
+			sum += _interpreter.Eval<double>(ExpressionText, _parameterValues);
 		}
 
 		return sum;

--- a/benchmark/DynamicExpresso.Benchmarks/Program.cs
+++ b/benchmark/DynamicExpresso.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -523,7 +523,9 @@ namespace DynamicExpresso
 		/// <returns></returns>
 		public object Eval(string expressionText, Type expressionType, params Parameter[] parameters)
 		{
-			return Parse(expressionText, expressionType, parameters).Invoke(parameters);
+			// Eval is intended for one-off expressions: prefer interpretation to avoid IL generation cost.
+			var lambda = ParseAsLambda(expressionText, expressionType, parameters, preferInterpretation: true);
+			return lambda.Invoke(parameters);
 		}
 
 		#endregion
@@ -548,7 +550,7 @@ namespace DynamicExpresso
 
 		#region Private methods
 
-		private Lambda ParseAsLambda(string expressionText, Type expressionType, Parameter[] parameters)
+		private Lambda ParseAsLambda(string expressionText, Type expressionType, Parameter[] parameters, bool preferInterpretation = false)
 		{
 			var arguments = new ParserArguments(
 				expressionText,
@@ -561,7 +563,7 @@ namespace DynamicExpresso
 			foreach (var visitor in Visitors)
 				expression = visitor.Visit(expression);
 
-			var lambda = new Lambda(expression, arguments);
+			var lambda = new Lambda(expression, arguments, preferInterpretation);
 
 #if TEST_DetectIdentifiers
 			AssertDetectIdentifiers(lambda);


### PR DESCRIPTION
## Stack

- **Prerequisite:** [#371](https://github.com/dynamicexpresso/DynamicExpresso/pull/371) -> **This PR:** [#372](https://github.com/dynamicexpresso/DynamicExpresso/pull/372)
###  [#372](https://github.com/dynamicexpresso/DynamicExpresso/pull/372) **currently contains all commits from** [#371](https://github.com/dynamicexpresso/DynamicExpresso/pull/371) plus **[one extra commit](https://github.com/dynamicexpresso/DynamicExpresso/compare/d8ca5df...94ab79d)**.


## What & why

`Invoke(object[])` is a common hot path. Even after #371, the fallback path still pays for:
- building `usedArgs` (when declared != used), and/or
- `DynamicInvoke` overhead.

This PR introduces an additional fast-path that, when applicable, bypasses both costs.

## Changes

- **Add a more aggressive `Invoke(object[])` fast-path:**
  - In `Lambda`’s internal `InvocationContext`, compile **once** a `Func<object[], object>` “fast invoker”.
  - When the declared argument array passed to `Invoke(object[])` meets the **type assignability / nullable-compatibility** constraints, invoke via the fast invoker:
    - **Avoids `DynamicInvoke`**
    - **Avoids constructing `usedArgs`**
  - Otherwise, fall back to the safe path:
    - build `usedArgs` + `DynamicInvoke`

## Benchmark results

Environment:

- BenchmarkDotNet `v0.14.0`
- Windows 11 (`10.0.26200.7705`)
- 11th Gen Intel Core i7-11800H (16 logical / 8 physical)
- .NET `8.0.23` (x64 RyuJIT)
- .NET SDK `10.0.102`

### Raw numbers

| Method | master Mean (ms) | PR #371 Mean (ms) | PR #372 Mean (ms) | master Alloc (MB) | PR #371 Alloc (MB) | PR #372 Alloc (MB) |
|---|---:|---:|---:|---:|---:|---:|
| Invoke cached lambda (object[]) | 221.70 | 10.04 | 2.867 | 260.93 | 9.16 | 2.29 |
| Invoke cached lambda (IEnumerable&lt;Parameter&gt;) | 175.80 | 96.20 | 97.169 | 191.50 | 37.38 | 37.38 |
| Eval (IEnumerable&lt;Parameter&gt;) | 25,503.70 | 16,346.04 | 16,821.122 | 17,172.52 | 16,800.18 | 16,781.66 |

### Derived comparisons

| Method | master → #371 speedup | master → #372 speedup | #371 → #372 speedup | master → #371 alloc reduction | master → #372 alloc reduction | #371 → #372 alloc reduction |
|---|---:|---:|---:|---:|---:|---:|
| Invoke cached lambda (object[]) | 22.08x | 77.31x | 3.50x | 28.49x | 113.94x | 4.00x |
| Invoke cached lambda (IEnumerable&lt;Parameter&gt;) | 1.83x | 1.81x | 0.99x | 5.12x | 5.12x | 1.00x |
| Eval (IEnumerable&lt;Parameter&gt;) | 1.56x | 1.52x | 0.97x | 1.02x | 1.02x | 1.00x |

Notes:
- PR [#372](https://github.com/dynamicexpresso/DynamicExpresso/pull/372) delivers an additional big win for **`Invoke(object[])`**:
  - vs PR [#371](https://github.com/dynamicexpresso/DynamicExpresso/pull/371): ~**3.5x faster**, ~**4x fewer allocations**
  - vs master: ~**77x faster**, ~**114x fewer allocations**
  (in this benchmark scenario)
- `Invoke(IEnumerable<Parameter>)` / `Eval(...)` are effectively unchanged from [#371](https://github.com/dynamicexpresso/DynamicExpresso/pull/371) — this fast-path is intentionally targeted at declared-order `object[]`.