### PR TITLE
docs: add TagBites.Expressions to the list of similar projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,8 @@ For one reason or another none of these projects exactly fit my needs so I decid
 - CS-Script - http://www.csscript.net/
 - IronJS, IronRuby, IronPython
 - paxScript.NET http://eco148-88394.innterhost.net/paxscriptnet/
-
+- TagBites.Expressions - Roslyn-based C# expression parser and evaluator - https://github.com/TagBites/TagBites.Expressions
+  
 ## Continuous Integration
 
 A continuous integration pipeline is configured using Github Actions, see `.github/workflows` folder.


### PR DESCRIPTION
I'm the author of TagBites.Expressions - https://github.com/TagBites/TagBites.Expressions

I used DynamicExpresso before and it worked well for me, so thanks for maintaining it! I needed to support a larger part of C# syntax than DynamicExpresso's do, so I used Roslyn to skip parsing and focus only on converting syntax tree to expression tree. This project is also on MIT license, so I hope someone find it helpful.